### PR TITLE
[#7] Feat : security JWT access token 발급 구현

### DIFF
--- a/src/main/java/com/darknights/devigation/DevigationApplication.java
+++ b/src/main/java/com/darknights/devigation/DevigationApplication.java
@@ -1,11 +1,14 @@
 package com.darknights.devigation;
 
+import com.darknights.devigation.configuration.AppProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
 @SpringBootApplication
+@EnableConfigurationProperties(AppProperties.class)
 public class DevigationApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/darknights/devigation/DevigationApplication.java
+++ b/src/main/java/com/darknights/devigation/DevigationApplication.java
@@ -2,7 +2,9 @@ package com.darknights.devigation;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class DevigationApplication {
 

--- a/src/main/java/com/darknights/devigation/common/annotation/CurrentMember.java
+++ b/src/main/java/com/darknights/devigation/common/annotation/CurrentMember.java
@@ -1,0 +1,12 @@
+package com.darknights.devigation.common.annotation;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.PARAMETER, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@AuthenticationPrincipal
+public @interface CurrentMember {
+}

--- a/src/main/java/com/darknights/devigation/common/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/com/darknights/devigation/common/filter/TokenAuthenticationFilter.java
@@ -1,0 +1,58 @@
+package com.darknights.devigation.common.filter;
+
+import com.darknights.devigation.security.command.application.service.CustomUserDetailService;
+import com.darknights.devigation.security.command.application.service.CustomTokenService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class TokenAuthenticationFilter extends OncePerRequestFilter {
+
+    @Autowired
+    private CustomTokenService customTokenService;
+
+    @Autowired
+    private CustomUserDetailService customUserDetailService;
+
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            String jwt = getJwtFromRequest(request);
+
+            if (StringUtils.hasText(jwt) && customTokenService.validateToken(jwt)) {
+                Long userId = customTokenService.getUserIdFromToken(jwt);
+
+                UserDetails userDetails = customUserDetailService.loadUserById(userId);
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        } catch (Exception e) {
+            logger.error("Could not set user authentication in security context", e);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String getJwtFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7, bearerToken.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/darknights/devigation/common/handler/CustomOAuth2FailHandler.java
+++ b/src/main/java/com/darknights/devigation/common/handler/CustomOAuth2FailHandler.java
@@ -1,0 +1,29 @@
+package com.darknights.devigation.common.handler;
+
+
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+
+@Component
+public class CustomOAuth2FailHandler extends SimpleUrlAuthenticationFailureHandler {
+
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+
+        System.out.println(request.getRequestURL());
+
+
+        getRedirectStrategy().sendRedirect(request, response, "/");
+    }
+}

--- a/src/main/java/com/darknights/devigation/common/handler/CustomOAuth2FailHandler.java
+++ b/src/main/java/com/darknights/devigation/common/handler/CustomOAuth2FailHandler.java
@@ -2,28 +2,49 @@ package com.darknights.devigation.common.handler;
 
 
 
+import com.darknights.devigation.security.command.domain.aggregate.util.CookieUtils;
+import com.darknights.devigation.security.command.domain.repository.HttpCookieOAuth2AuthorizationRequestRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 
 
 import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 
+import static com.darknights.devigation.security.command.domain.repository.HttpCookieOAuth2AuthorizationRequestRepository.REDIRECT_URI_PARAM_COOKIE_NAME;
+
 
 @Component
 public class CustomOAuth2FailHandler extends SimpleUrlAuthenticationFailureHandler {
 
+    private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
+
+    @Autowired
+    public CustomOAuth2FailHandler(HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository) {
+        this.httpCookieOAuth2AuthorizationRequestRepository = httpCookieOAuth2AuthorizationRequestRepository;
+
+    }
 
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        String targetUrl;
+        targetUrl = CookieUtils.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
+                .map(Cookie::getValue)
+                .orElse(("/"));
 
-        System.out.println(request.getRequestURL());
+        targetUrl = UriComponentsBuilder.fromUriString(targetUrl)
+                .queryParam("error", exception.getLocalizedMessage())
+                .build().toUriString();
 
+        httpCookieOAuth2AuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
 
-        getRedirectStrategy().sendRedirect(request, response, "/");
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
     }
 }

--- a/src/main/java/com/darknights/devigation/common/handler/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/darknights/devigation/common/handler/CustomOAuth2SuccessHandler.java
@@ -85,11 +85,8 @@ public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHa
                 .anyMatch(authorizedRedirectUri -> {
                     // Only validate host and port. Let the clients use different paths if they want to
                     URI authorizedURI = URI.create(authorizedRedirectUri);
-                    if(authorizedURI.getHost().equalsIgnoreCase(clientRedirectUri.getHost())
-                            && authorizedURI.getPort() == clientRedirectUri.getPort()) {
-                        return true;
-                    }
-                    return false;
+                    return authorizedURI.getHost().equalsIgnoreCase(clientRedirectUri.getHost())
+                            && authorizedURI.getPort() == clientRedirectUri.getPort();
                 });
     }
 

--- a/src/main/java/com/darknights/devigation/common/handler/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/darknights/devigation/common/handler/CustomOAuth2SuccessHandler.java
@@ -1,0 +1,28 @@
+package com.darknights.devigation.common.handler;
+
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+
+
+@Component
+public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+
+        String targetUrl = determineTargetUrl(request, response, authentication);
+
+        clearAuthenticationAttributes(request);
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+
+}

--- a/src/main/java/com/darknights/devigation/common/handler/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/darknights/devigation/common/handler/CustomOAuth2SuccessHandler.java
@@ -1,28 +1,96 @@
 package com.darknights.devigation.common.handler;
 
 
+import com.darknights.devigation.configuration.AppProperties;
+import com.darknights.devigation.security.command.application.service.CustomTokenService;
+import com.darknights.devigation.security.command.domain.aggregate.util.CookieUtils;
+import com.darknights.devigation.security.command.domain.exception.BadRequestException;
+import com.darknights.devigation.security.command.domain.repository.HttpCookieOAuth2AuthorizationRequestRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.Cookie;
 import java.io.IOException;
+import java.net.URI;
+import java.util.Optional;
 
+import static com.darknights.devigation.security.command.domain.repository.HttpCookieOAuth2AuthorizationRequestRepository.REDIRECT_URI_PARAM_COOKIE_NAME;
 
 
 @Component
 public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
+    private CustomTokenService customTokenService;
+
+    private AppProperties appProperties;
+
+    private HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
+
+    @Autowired
+    CustomOAuth2SuccessHandler(CustomTokenService customTokenService, AppProperties appProperties,
+                               HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository) {
+        this.customTokenService = customTokenService;
+        this.appProperties = appProperties;
+        this.httpCookieOAuth2AuthorizationRequestRepository = httpCookieOAuth2AuthorizationRequestRepository;
+    }
+
+
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
-
         String targetUrl = determineTargetUrl(request, response, authentication);
 
-        clearAuthenticationAttributes(request);
+        if (response.isCommitted()) {
+            logger.debug("Response has already been committed. Unable to redirect to " + targetUrl);
+            return;
+        }
+
+        clearAuthenticationAttributes(request, response);
         getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+
+    protected String determineTargetUrl(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+        Optional<String> redirectUri = CookieUtils.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
+                .map(Cookie::getValue);
+
+        if(redirectUri.isPresent() && !isAuthorizedRedirectUri(redirectUri.get())) {
+            throw new BadRequestException("Sorry! We've got an Unauthorized Redirect URI and can't proceed with the authentication");
+        }
+
+        String targetUrl = redirectUri.orElse(getDefaultTargetUrl());
+
+        String token = customTokenService.createToken(authentication);
+
+        return UriComponentsBuilder.fromUriString(targetUrl)
+                .queryParam("token", token)
+                .build().toUriString();
+    }
+
+    protected void clearAuthenticationAttributes(HttpServletRequest request, HttpServletResponse response) {
+        super.clearAuthenticationAttributes(request);
+        httpCookieOAuth2AuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+    }
+
+    private boolean isAuthorizedRedirectUri(String uri) {
+        URI clientRedirectUri = URI.create(uri);
+
+        return appProperties.getOauth2().getAuthorizedRedirectUris()
+                .stream()
+                .anyMatch(authorizedRedirectUri -> {
+                    // Only validate host and port. Let the clients use different paths if they want to
+                    URI authorizedURI = URI.create(authorizedRedirectUri);
+                    if(authorizedURI.getHost().equalsIgnoreCase(clientRedirectUri.getHost())
+                            && authorizedURI.getPort() == clientRedirectUri.getPort()) {
+                        return true;
+                    }
+                    return false;
+                });
     }
 
 }

--- a/src/main/java/com/darknights/devigation/common/handler/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/darknights/devigation/common/handler/CustomOAuth2SuccessHandler.java
@@ -27,11 +27,11 @@ import static com.darknights.devigation.security.command.domain.repository.HttpC
 @Component
 public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
-    private CustomTokenService customTokenService;
+    private final CustomTokenService customTokenService;
 
-    private AppProperties appProperties;
+    private final AppProperties appProperties;
 
-    private HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
+    private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
 
     @Autowired
     CustomOAuth2SuccessHandler(CustomTokenService customTokenService, AppProperties appProperties,

--- a/src/main/java/com/darknights/devigation/configuration/AppProperties.java
+++ b/src/main/java/com/darknights/devigation/configuration/AppProperties.java
@@ -1,0 +1,58 @@
+package com.darknights.devigation.configuration;
+
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@ConfigurationProperties(prefix = "app")
+public class AppProperties {
+
+    private final Auth auth = new Auth();
+    private final OAuth2 oauth2 = new OAuth2();
+
+    public static class Auth {
+        private String tokenSecret;
+        private long tokenExpirationMsec;
+
+        public String getTokenSecret() {
+            return tokenSecret;
+        }
+
+        public void setTokenSecret(String tokenSecret) {
+            this.tokenSecret = tokenSecret;
+        }
+
+        public long getTokenExpirationMsec() {
+            return tokenExpirationMsec;
+        }
+
+        public void setTokenExpirationMsec(long tokenExpirationMsec) {
+            this.tokenExpirationMsec = tokenExpirationMsec;
+        }
+    }
+
+    public static final class OAuth2 {
+        private List<String> authorizedRedirectUris = new ArrayList<>();
+
+        public List<String> getAuthorizedRedirectUris() {
+            return authorizedRedirectUris;
+        }
+
+        public OAuth2 authorizedRedirectUris(List<String> authorizedRedirectUris) {
+            this.authorizedRedirectUris = authorizedRedirectUris;
+            return this;
+        }
+    }
+
+    public Auth getAuth() {
+        return auth;
+    }
+
+    public OAuth2 getOauth2() {
+        return oauth2;
+    }
+
+}

--- a/src/main/java/com/darknights/devigation/configuration/AppProperties.java
+++ b/src/main/java/com/darknights/devigation/configuration/AppProperties.java
@@ -2,7 +2,6 @@ package com.darknights.devigation.configuration;
 
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/darknights/devigation/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/darknights/devigation/configuration/SecurityConfiguration.java
@@ -1,0 +1,65 @@
+package com.darknights.devigation.configuration;
+
+import com.darknights.devigation.common.handler.CustomOAuth2FailHandler;
+import com.darknights.devigation.common.handler.CustomOAuth2SuccessHandler;
+import com.darknights.devigation.security.command.application.service.CustomOAuth2UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@RequiredArgsConstructor
+@EnableWebSecurity
+public class SecurityConfiguration {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final CustomOAuth2SuccessHandler oAuth2AuthenticationSuccessHandler;
+    private final CustomOAuth2FailHandler oAuth2AuthenticationFailureHandler;
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        http
+                .cors()
+                .and()
+                .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .csrf()
+                .disable()
+                .formLogin()
+                .disable()
+
+                .authorizeRequests()
+                    .antMatchers("/", "/error","/favicon.ico", "/**/*.png", "/**/*.gif", "/**/*.svg", "/**/*.jpg", "/**/*.html", "/**/*.css", "/**/*.js")
+                        .permitAll()
+                    .antMatchers("/swagger", "/swagger-ui.html", "/swagger-ui/**", "/api-docs", "/api-docs/**", "/v3/api-docs/**")
+                        .permitAll()
+                    .antMatchers("/login/**","/auth/**", "/oauth2/**")
+                        .permitAll()
+                    .antMatchers("/blog/**")
+                        .permitAll()
+                    .anyRequest()
+                        .authenticated()
+                    .and()
+                .oauth2Login()
+                    .authorizationEndpoint()
+                        .baseUri("/oauth2/authorize")
+
+                    .and()
+                    .userInfoEndpoint()
+                        .userService(customOAuth2UserService);
+
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/darknights/devigation/configuration/WebMvcConfiguration.java
+++ b/src/main/java/com/darknights/devigation/configuration/WebMvcConfiguration.java
@@ -1,0 +1,28 @@
+package com.darknights.devigation.configuration;
+
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfiguration implements WebMvcConfigurer {
+
+    private final long MAX_AGE_SECS = 3600;
+
+    @Value("${app.cors.allowedOrigins}")
+    private String[] allowedOrigins;
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins(allowedOrigins)
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true)
+                .maxAge(MAX_AGE_SECS);
+    }
+
+
+}

--- a/src/main/java/com/darknights/devigation/member/command/application/dto/CreateMemberDTO.java
+++ b/src/main/java/com/darknights/devigation/member/command/application/dto/CreateMemberDTO.java
@@ -10,15 +10,13 @@ public class CreateMemberDTO {
     private final String name;
     private final Role role;
     private final String profileImage;
-    private final String accessToken;
     private final PlatformEnum platformEnum;
 
-    public CreateMemberDTO(String UID, String name, Role role, String profileImage, String accessToken, PlatformEnum platformEnum) {
+    public CreateMemberDTO(String UID, String name, Role role, String profileImage, PlatformEnum platformEnum) {
         this.UID = UID;
         this.name = name;
         this.role = role;
         this.profileImage = profileImage;
-        this.accessToken = accessToken;
         this.platformEnum = platformEnum;
     }
 }

--- a/src/main/java/com/darknights/devigation/member/command/application/dto/CreateMemberDTO.java
+++ b/src/main/java/com/darknights/devigation/member/command/application/dto/CreateMemberDTO.java
@@ -10,12 +10,14 @@ public class CreateMemberDTO {
     private final String name;
     private final Role role;
     private final String profileImage;
+    private final String email;
     private final PlatformEnum platformEnum;
 
-    public CreateMemberDTO(String UID, String name, Role role, String profileImage, PlatformEnum platformEnum) {
+    public CreateMemberDTO(String UID, String name, Role role, String email, String profileImage, PlatformEnum platformEnum) {
         this.UID = UID;
         this.name = name;
         this.role = role;
+        this.email = email;
         this.profileImage = profileImage;
         this.platformEnum = platformEnum;
     }

--- a/src/main/java/com/darknights/devigation/member/command/application/dto/UpdateMemberDTO.java
+++ b/src/main/java/com/darknights/devigation/member/command/application/dto/UpdateMemberDTO.java
@@ -1,0 +1,31 @@
+package com.darknights.devigation.member.command.application.dto;
+
+import com.darknights.devigation.member.command.domain.aggregate.entity.enumType.PlatformEnum;
+import com.darknights.devigation.member.command.domain.aggregate.entity.enumType.Role;
+import lombok.Getter;
+import lombok.Setter;
+
+
+@Getter
+@Setter
+public class UpdateMemberDTO {
+
+    private String UID;
+    private String name;
+    private Role role;
+    private String profileImage;
+    private PlatformEnum platformEnum;
+
+    public UpdateMemberDTO(String UID, String name, Role role, String profileImage, PlatformEnum platformEnum) {
+        this.UID = UID;
+        this.name = name;
+        this.role = role;
+        this.profileImage = profileImage;
+        this.platformEnum = platformEnum;
+    }
+
+    public UpdateMemberDTO(String profileImage, String name) {
+        this.profileImage = profileImage;
+        this.name = name;
+    }
+}

--- a/src/main/java/com/darknights/devigation/member/command/application/service/CreateMemberService.java
+++ b/src/main/java/com/darknights/devigation/member/command/application/service/CreateMemberService.java
@@ -19,7 +19,6 @@ public class CreateMemberService {
     public Member create(CreateMemberDTO createMemberDTO) {
         Member createdMember = new Member(
                 createMemberDTO.getName(),
-                createMemberDTO.getAccessToken(),
                 createMemberDTO.getUID(),
                 createMemberDTO.getProfileImage(),
                 createMemberDTO.getPlatformEnum(),

--- a/src/main/java/com/darknights/devigation/member/command/application/service/CreateMemberService.java
+++ b/src/main/java/com/darknights/devigation/member/command/application/service/CreateMemberService.java
@@ -20,6 +20,7 @@ public class CreateMemberService {
         Member createdMember = new Member(
                 createMemberDTO.getName(),
                 createMemberDTO.getUID(),
+                createMemberDTO.getEmail(),
                 createMemberDTO.getProfileImage(),
                 createMemberDTO.getPlatformEnum(),
                 createMemberDTO.getRole()

--- a/src/main/java/com/darknights/devigation/member/command/application/service/UpdateMemberService.java
+++ b/src/main/java/com/darknights/devigation/member/command/application/service/UpdateMemberService.java
@@ -1,0 +1,33 @@
+package com.darknights.devigation.member.command.application.service;
+
+import com.darknights.devigation.member.command.application.dto.UpdateMemberDTO;
+import com.darknights.devigation.member.command.domain.aggregate.entity.Member;
+import com.darknights.devigation.member.command.domain.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.Optional;
+
+@Service
+public class UpdateMemberService {
+
+    private final MemberRepository memberRepository;
+
+    public UpdateMemberService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    @Transactional
+    public boolean update(long memberId, UpdateMemberDTO updateMemberDTO) {
+        Optional<Member> findMember = memberRepository.findById(memberId);
+        if (findMember.isPresent()) {
+            Member updateMember = findMember.get();
+            if (updateMemberDTO.getProfileImage() != null) {
+                updateMember.setProfileImage(updateMemberDTO.getProfileImage());
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/darknights/devigation/member/command/domain/aggregate/entity/Member.java
+++ b/src/main/java/com/darknights/devigation/member/command/domain/aggregate/entity/Member.java
@@ -21,7 +21,7 @@ public class Member {
     @Column(length = 100, nullable = false)
     private String name;
 
-    @Column(nullable = false, name = "access_token")
+    @Column(nullable = true, name = "access_token")
     private String accessToken;
 
     @Column(nullable = false, name = "uid")
@@ -44,9 +44,8 @@ public class Member {
 
     protected Member() {};
 
-    public Member(String name, String accessToken, String UID, String profileImage, PlatformEnum platform, Role role) {
+    public Member(String name, String UID, String profileImage, PlatformEnum platform, Role role) {
         this.name = name;
-        this.accessToken = accessToken;
         this.UID = UID;
         this.profileImage = profileImage;
         this.platform = platform;

--- a/src/main/java/com/darknights/devigation/member/command/domain/aggregate/entity/Member.java
+++ b/src/main/java/com/darknights/devigation/member/command/domain/aggregate/entity/Member.java
@@ -24,6 +24,9 @@ public class Member {
     @Column(nullable = true, name = "access_token")
     private String accessToken;
 
+    @Column(nullable = false, name = "email", unique = true)
+    private String email;
+
     @Column(nullable = false, name = "uid")
     private String UID;
 
@@ -44,10 +47,11 @@ public class Member {
 
     protected Member() {};
 
-    public Member(String name, String UID, String profileImage, PlatformEnum platform, Role role) {
+    public Member(String name, String UID, String profileImage, String email ,PlatformEnum platform, Role role) {
         this.name = name;
         this.UID = UID;
         this.profileImage = profileImage;
+        this.email = email;
         this.platform = platform;
         this.role = role;
         this.createdDate = LocalDateTime.now();

--- a/src/main/java/com/darknights/devigation/member/query/application/service/FindMemberService.java
+++ b/src/main/java/com/darknights/devigation/member/query/application/service/FindMemberService.java
@@ -6,8 +6,6 @@ import com.darknights.devigation.member.query.domain.repository.MemberMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.Optional;
-
 @Service
 public class FindMemberService {
 

--- a/src/main/java/com/darknights/devigation/member/query/application/service/FindMemberService.java
+++ b/src/main/java/com/darknights/devigation/member/query/application/service/FindMemberService.java
@@ -17,14 +17,18 @@ public class FindMemberService {
 
     public FindMemberDTO findByUID(String uid) {
         QueryMember findMember = memberMapper.findByUID(uid);
-        return new FindMemberDTO(
-                findMember.getId(),
-                findMember.getName(),
-                findMember.getAccessToken(),
-                findMember.getProfileImage(),
-                findMember.getPlatform().name(),
-                findMember.getRole().name()
-        );
+        if(findMember == null) {
+            return null;
+        } else {
+            return new FindMemberDTO(
+                    findMember.getId(),
+                    findMember.getName(),
+                    findMember.getAccessToken(),
+                    findMember.getProfileImage(),
+                    findMember.getPlatform().name(),
+                    findMember.getRole().name()
+            );
+        }
     }
 
     public FindMemberDTO findByAccessToken(String accessToken) {

--- a/src/main/java/com/darknights/devigation/member/query/application/service/FindMemberService.java
+++ b/src/main/java/com/darknights/devigation/member/query/application/service/FindMemberService.java
@@ -6,6 +6,8 @@ import com.darknights.devigation.member.query.domain.repository.MemberMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
 public class FindMemberService {
 
@@ -46,6 +48,20 @@ public class FindMemberService {
     public FindMemberDTO findById(long memberId) {
 
         QueryMember findMember = memberMapper.findById(memberId);
+
+        return new FindMemberDTO(
+                findMember.getId(),
+                findMember.getName(),
+                findMember.getAccessToken(),
+                findMember.getProfileImage(),
+                findMember.getPlatform().name(),
+                findMember.getRole().name()
+        );
+    }
+
+    public FindMemberDTO  findByEmail(String email) {
+
+        QueryMember findMember = memberMapper.findByEmail(email);
 
         return new FindMemberDTO(
                 findMember.getId(),

--- a/src/main/java/com/darknights/devigation/member/query/domain/aggregate/entity/QueryMember.java
+++ b/src/main/java/com/darknights/devigation/member/query/domain/aggregate/entity/QueryMember.java
@@ -21,7 +21,7 @@ public class QueryMember {
     @Column(length = 100, nullable = false)
     private String name;
 
-    @Column(nullable = false, name = "access_token")
+    @Column(nullable = true, name = "access_token")
     private String accessToken;
 
     @Column(nullable = false, name = "uid")

--- a/src/main/java/com/darknights/devigation/member/query/domain/aggregate/entity/QueryMember.java
+++ b/src/main/java/com/darknights/devigation/member/query/domain/aggregate/entity/QueryMember.java
@@ -27,6 +27,9 @@ public class QueryMember {
     @Column(nullable = false, name = "uid")
     private String UID;
 
+    @Column(nullable = false, name = "email", unique = true)
+    private String email;
+
     @Column(length = 300, name = "profile_image", nullable = false)
     private String profileImage;
 

--- a/src/main/java/com/darknights/devigation/member/query/domain/repository/MemberMapper.java
+++ b/src/main/java/com/darknights/devigation/member/query/domain/repository/MemberMapper.java
@@ -14,4 +14,6 @@ public interface MemberMapper {
     QueryMember findByUID(String uid);
 
     QueryMember findByAccessToken(String accessToken);
+
+    QueryMember findByEmail(String email);
 }

--- a/src/main/java/com/darknights/devigation/security/command/application/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/darknights/devigation/security/command/application/service/CustomOAuth2UserService.java
@@ -1,0 +1,73 @@
+package com.darknights.devigation.security.command.application.service;
+
+import com.darknights.devigation.security.command.domain.provider.OAuth2UserInfo;
+import com.darknights.devigation.security.command.domain.provider.OAuth2UserInfoFactory;
+import com.darknights.devigation.security.token.UserPrincipal;
+import com.darknights.devigation.member.command.application.dto.CreateMemberDTO;
+import com.darknights.devigation.member.command.application.dto.UpdateMemberDTO;
+import com.darknights.devigation.member.command.application.service.CreateMemberService;
+import com.darknights.devigation.member.command.application.service.UpdateMemberService;
+import com.darknights.devigation.member.command.domain.aggregate.entity.Member;
+import com.darknights.devigation.member.command.domain.aggregate.entity.enumType.PlatformEnum;
+import com.darknights.devigation.member.command.domain.aggregate.entity.enumType.Role;
+import com.darknights.devigation.member.query.application.dto.FindMemberDTO;
+import com.darknights.devigation.member.query.application.service.FindMemberService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Transactional
+@Service
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final FindMemberService findMemberService;
+    private final CreateMemberService createMemberService;
+    private final UpdateMemberService updateMemberService;
+
+    @Autowired
+    public CustomOAuth2UserService(FindMemberService findMemberService, CreateMemberService createMemberService, UpdateMemberService updateMemberService) {
+        this.findMemberService = findMemberService;
+        this.createMemberService = createMemberService;
+        this.updateMemberService = updateMemberService;
+    }
+
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest oAuth2UserRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(oAuth2UserRequest);
+        System.out.println("oAuth2User = " + oAuth2User.toString());
+            String registrationId = oAuth2UserRequest.getClientRegistration().getRegistrationId(); // 소셜 정보 가져옴
+
+            System.out.println("registrationId = " + registrationId);
+
+            String userNameAttributeName = oAuth2UserRequest.getClientRegistration().getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+            System.out.println("userNameAttributeName = " + userNameAttributeName);
+            OAuth2UserInfo attributes = OAuth2UserInfoFactory.getOAuth2UserInfo(registrationId, oAuth2User.getAttributes());
+            System.out.println("attributes = " + attributes.getAttributes());
+
+            UserPrincipal socialMember =  saveOrUpdate(attributes, registrationId);
+            return socialMember;
+    }
+
+    private UserPrincipal saveOrUpdate(OAuth2UserInfo attributes, String provider) {
+        FindMemberDTO member = findMemberService.findByUID(attributes.getId());
+        System.out.println("member = " + member);
+        UserPrincipal oauthMember;
+        if (member == null) {
+            CreateMemberDTO createMemberDTO = new CreateMemberDTO(attributes.getId(), attributes.getName(), Role.MEMBER, attributes.getImageUrl(), PlatformEnum.valueOf(provider.toUpperCase()));
+            Member newMember = createMemberService.create(createMemberDTO);
+            oauthMember = UserPrincipal.create(newMember, attributes.getAttributes());
+        } else {
+            UpdateMemberDTO updateMemberDTO = new UpdateMemberDTO(attributes.getImageUrl(), attributes.getName());
+            boolean updateMemberResult = updateMemberService.update(member.getId(), updateMemberDTO);
+            oauthMember = UserPrincipal.create(member, attributes.getAttributes());
+        }
+        return oauthMember;
+    }
+
+}

--- a/src/main/java/com/darknights/devigation/security/command/application/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/darknights/devigation/security/command/application/service/CustomOAuth2UserService.java
@@ -40,15 +40,11 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     @Override
     public OAuth2User loadUser(OAuth2UserRequest oAuth2UserRequest) throws OAuth2AuthenticationException {
         OAuth2User oAuth2User = super.loadUser(oAuth2UserRequest);
-        System.out.println("oAuth2User = " + oAuth2User.toString());
             String registrationId = oAuth2UserRequest.getClientRegistration().getRegistrationId(); // 소셜 정보 가져옴
 
-            System.out.println("registrationId = " + registrationId);
-
             String userNameAttributeName = oAuth2UserRequest.getClientRegistration().getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
-            System.out.println("userNameAttributeName = " + userNameAttributeName);
+
             OAuth2UserInfo attributes = OAuth2UserInfoFactory.getOAuth2UserInfo(registrationId, oAuth2User.getAttributes());
-            System.out.println("attributes = " + attributes.getAttributes());
 
             UserPrincipal socialMember =  saveOrUpdate(attributes, registrationId);
             return socialMember;
@@ -59,7 +55,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         System.out.println("member = " + member);
         UserPrincipal oauthMember;
         if (member == null) {
-            CreateMemberDTO createMemberDTO = new CreateMemberDTO(attributes.getId(), attributes.getName(), Role.MEMBER, attributes.getImageUrl(), PlatformEnum.valueOf(provider.toUpperCase()));
+            CreateMemberDTO createMemberDTO = new CreateMemberDTO(attributes.getId(), attributes.getName(), Role.MEMBER, attributes.getImageUrl(), attributes.getEmail(), PlatformEnum.valueOf(provider.toUpperCase()));
             Member newMember = createMemberService.create(createMemberDTO);
             oauthMember = UserPrincipal.create(newMember, attributes.getAttributes());
         } else {

--- a/src/main/java/com/darknights/devigation/security/command/application/service/CustomTokenService.java
+++ b/src/main/java/com/darknights/devigation/security/command/application/service/CustomTokenService.java
@@ -28,9 +28,9 @@ public class CustomTokenService {
 
         byte[] keyBytes = Decoders.BASE64.decode(appProperties.getAuth().getTokenSecret());
         Key key = Keys.hmacShaKeyFor(keyBytes);
-
         return Jwts.builder()
                 .setSubject(Long.toString(userPrincipal.getId()))
+                .claim("role", userPrincipal.getRole())
                 .setIssuedAt(new Date())
                 .setExpiration(expiryDate)
                 .signWith(key,SignatureAlgorithm.HS256)
@@ -55,14 +55,14 @@ public class CustomTokenService {
         try {
             Jwts.parser().setSigningKey(appProperties.getAuth().getTokenSecret()).parseClaimsJws(authToken);
             return true;
-        } catch (MalformedJwtException ex) {
-            System.out.println("Invalid JWT token");
+        } catch (SecurityException | MalformedJwtException ex) {
+            System.out.println("잘못된 JWT 서명입니다.");
         } catch (ExpiredJwtException ex) {
-            System.out.println("Expired JWT token");
+            System.out.println("만료된 JWT 토큰입니다.");
         } catch (UnsupportedJwtException ex) {
-            System.out.println("Unsupported JWT token");
+            System.out.println("지원되지 않는 JWT 토큰입니다.");
         } catch (IllegalArgumentException ex) {
-            System.out.println("JWT claims string is empty.");
+            System.out.println("JWT 토큰이 잘못되었습니다.");
         }
         return false;
     }

--- a/src/main/java/com/darknights/devigation/security/command/application/service/CustomTokenService.java
+++ b/src/main/java/com/darknights/devigation/security/command/application/service/CustomTokenService.java
@@ -14,7 +14,7 @@ import java.util.Date;
 @Service
 public class CustomTokenService {
 
-    private AppProperties appProperties;
+    private final AppProperties appProperties;
 
     public CustomTokenService(AppProperties appProperties) {
         this.appProperties = appProperties;
@@ -53,7 +53,8 @@ public class CustomTokenService {
 
     public boolean validateToken(String authToken) {
         try {
-            Jwts.parser().setSigningKey(appProperties.getAuth().getTokenSecret()).parseClaimsJws(authToken);
+            //Jwts.parser().setSigningKey(appProperties.getAuth().getTokenSecret()).parseClaimsJws(authToken);
+            Jwts.parserBuilder().setSigningKey(appProperties.getAuth().getTokenSecret()).build().parseClaimsJws(authToken);
             return true;
         } catch (SecurityException | MalformedJwtException ex) {
             System.out.println("잘못된 JWT 서명입니다.");

--- a/src/main/java/com/darknights/devigation/security/command/application/service/CustomTokenService.java
+++ b/src/main/java/com/darknights/devigation/security/command/application/service/CustomTokenService.java
@@ -1,0 +1,70 @@
+package com.darknights.devigation.security.command.application.service;
+
+import com.darknights.devigation.configuration.AppProperties;
+import com.darknights.devigation.security.token.UserPrincipal;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+import java.security.Key;
+import java.util.Date;
+
+@Service
+public class CustomTokenService {
+
+    private AppProperties appProperties;
+
+    public CustomTokenService(AppProperties appProperties) {
+        this.appProperties = appProperties;
+    }
+
+    public String createToken(Authentication authentication) {
+        UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();
+
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + appProperties.getAuth().getTokenExpirationMsec());
+
+        byte[] keyBytes = Decoders.BASE64.decode(appProperties.getAuth().getTokenSecret());
+        Key key = Keys.hmacShaKeyFor(keyBytes);
+
+        return Jwts.builder()
+                .setSubject(Long.toString(userPrincipal.getId()))
+                .setIssuedAt(new Date())
+                .setExpiration(expiryDate)
+                .signWith(key,SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public Long getUserIdFromToken(String token) {
+
+        byte[] keyBytes = Decoders.BASE64.decode(appProperties.getAuth().getTokenSecret());
+        Key key = Keys.hmacShaKeyFor(keyBytes);
+
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        return Long.parseLong(claims.getSubject());
+    }
+
+    public boolean validateToken(String authToken) {
+        try {
+            Jwts.parser().setSigningKey(appProperties.getAuth().getTokenSecret()).parseClaimsJws(authToken);
+            return true;
+        } catch (MalformedJwtException ex) {
+            System.out.println("Invalid JWT token");
+        } catch (ExpiredJwtException ex) {
+            System.out.println("Expired JWT token");
+        } catch (UnsupportedJwtException ex) {
+            System.out.println("Unsupported JWT token");
+        } catch (IllegalArgumentException ex) {
+            System.out.println("JWT claims string is empty.");
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/com/darknights/devigation/security/command/application/service/CustomUserDetailService.java
+++ b/src/main/java/com/darknights/devigation/security/command/application/service/CustomUserDetailService.java
@@ -1,0 +1,36 @@
+package com.darknights.devigation.security.command.application.service;
+
+import com.darknights.devigation.member.query.application.dto.FindMemberDTO;
+import com.darknights.devigation.member.query.application.service.FindMemberService;
+import com.darknights.devigation.security.token.UserPrincipal;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+@Service
+public class CustomUserDetailService implements UserDetailsService {
+
+    private final FindMemberService findMemberService;
+
+    @Autowired
+    public CustomUserDetailService(FindMemberService findMemberService) {
+        this.findMemberService = findMemberService;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+            FindMemberDTO member = findMemberService.findByEmail(email);
+            return UserPrincipal.create(member);
+    }
+
+    @Transactional
+    public UserDetails loadUserById(Long id) {
+        FindMemberDTO member = findMemberService.findById(id);
+
+        return UserPrincipal.create(member);
+    }
+}

--- a/src/main/java/com/darknights/devigation/security/command/application/service/RestAuthenticationEntryPoint.java
+++ b/src/main/java/com/darknights/devigation/security/command/application/service/RestAuthenticationEntryPoint.java
@@ -1,0 +1,16 @@
+package com.darknights.devigation.security.command.application.service;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, authException.getLocalizedMessage());
+    }
+}

--- a/src/main/java/com/darknights/devigation/security/command/domain/aggregate/util/CookieUtils.java
+++ b/src/main/java/com/darknights/devigation/security/command/domain/aggregate/util/CookieUtils.java
@@ -1,0 +1,57 @@
+package com.darknights.devigation.security.command.domain.aggregate.util;
+
+import org.springframework.util.SerializationUtils;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Base64;
+import java.util.Optional;
+
+public class CookieUtils {
+    public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies != null && cookies.length > 0) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(name)) {
+                    return Optional.of(cookie);
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(maxAge);
+        response.addCookie(cookie);
+    }
+
+    public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null && cookies.length > 0) {
+            for (Cookie cookie: cookies) {
+                if (cookie.getName().equals(name)) {
+                    cookie.setValue("");
+                    cookie.setPath("/");
+                    cookie.setMaxAge(0);
+                    response.addCookie(cookie);
+                }
+            }
+        }
+    }
+
+    public static String serialize(Object object) {
+        return Base64.getUrlEncoder()
+                .encodeToString(SerializationUtils.serialize(object));
+    }
+
+    public static <T> T deserialize(Cookie cookie, Class<T> cls) {
+        return cls.cast(SerializationUtils.deserialize(
+                Base64.getUrlDecoder().decode(cookie.getValue())));
+    }
+}

--- a/src/main/java/com/darknights/devigation/security/command/domain/exception/BadRequestException.java
+++ b/src/main/java/com/darknights/devigation/security/command/domain/exception/BadRequestException.java
@@ -1,0 +1,16 @@
+package com.darknights.devigation.security.command.domain.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(String message) {
+        super(message);
+    }
+
+    public BadRequestException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/com/darknights/devigation/security/command/domain/exception/OAuth2AuthenticationProcessingException.java
+++ b/src/main/java/com/darknights/devigation/security/command/domain/exception/OAuth2AuthenticationProcessingException.java
@@ -1,0 +1,14 @@
+package com.darknights.devigation.security.command.domain.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class OAuth2AuthenticationProcessingException extends AuthenticationException {
+
+    public OAuth2AuthenticationProcessingException(String msg, Throwable t) {
+        super(msg, t);
+    }
+
+    public OAuth2AuthenticationProcessingException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/com/darknights/devigation/security/command/domain/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/darknights/devigation/security/command/domain/exception/ResourceNotFoundException.java
@@ -1,0 +1,31 @@
+package com.darknights.devigation.security.command.domain.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class ResourceNotFoundException extends RuntimeException {
+
+    private String resourceName;
+    private String fieldName;
+    private Object fieldValue;
+
+    public ResourceNotFoundException(String resourceName, String fieldName, Object fieldValue) {
+        super(String.format("%s not found with %s : '%s'", resourceName, fieldName, fieldValue));
+        this.resourceName = resourceName;
+        this.fieldName = fieldName;
+        this.fieldValue = fieldValue;
+    }
+
+    public String getResourceName() {
+        return resourceName;
+    }
+
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    public Object getFieldValue() {
+        return fieldValue;
+    }
+}

--- a/src/main/java/com/darknights/devigation/security/command/domain/provider/Github.java
+++ b/src/main/java/com/darknights/devigation/security/command/domain/provider/Github.java
@@ -1,0 +1,41 @@
+package com.darknights.devigation.security.command.domain.provider;
+
+import com.darknights.devigation.member.query.domain.aggregate.entity.enumType.PlatformEnum;
+
+import java.util.Map;
+
+public class Github extends OAuth2UserInfo {
+
+    public Github(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+
+        return String.valueOf(attributes.get("id"));
+    }
+
+    @Override
+    public String getName() {
+
+        return (String) attributes.get("name");
+    }
+
+    @Override
+    public String getEmail() {
+
+        return (String) attributes.get("email");
+    }
+
+    @Override
+    public String getImageUrl() {
+
+        return (String) attributes.get("avatar_url");
+    }
+
+    @Override
+    public String getProvider(){
+        return PlatformEnum.GITHUB.name();
+    }
+}

--- a/src/main/java/com/darknights/devigation/security/command/domain/provider/OAuth2UserInfo.java
+++ b/src/main/java/com/darknights/devigation/security/command/domain/provider/OAuth2UserInfo.java
@@ -1,0 +1,25 @@
+package com.darknights.devigation.security.command.domain.provider;
+
+import java.util.Map;
+
+public abstract class OAuth2UserInfo {
+    protected Map<String, Object> attributes;
+
+    public OAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    public abstract String getProvider();
+
+    public abstract String getId();
+
+    public abstract String getName();
+
+    public abstract String getEmail();
+
+    public abstract String getImageUrl();
+}

--- a/src/main/java/com/darknights/devigation/security/command/domain/provider/OAuth2UserInfoFactory.java
+++ b/src/main/java/com/darknights/devigation/security/command/domain/provider/OAuth2UserInfoFactory.java
@@ -1,0 +1,15 @@
+package com.darknights.devigation.security.command.domain.provider;
+
+import com.darknights.devigation.member.query.domain.aggregate.entity.enumType.PlatformEnum;
+
+import java.util.Map;
+
+public class OAuth2UserInfoFactory {
+    public static OAuth2UserInfo getOAuth2UserInfo(String registrationId, Map<String, Object> attributes) {
+        if(registrationId.equalsIgnoreCase(PlatformEnum.GITHUB.name())) {
+            return new Github(attributes);
+        } else {
+            throw new IllegalArgumentException("해당 OAuth2 제공자는 지원하지 않습니다");
+        }
+    }
+}

--- a/src/main/java/com/darknights/devigation/security/command/domain/repository/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/darknights/devigation/security/command/domain/repository/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -1,0 +1,51 @@
+package com.darknights.devigation.security.command.domain.repository;
+
+import com.darknights.devigation.security.command.domain.aggregate.util.CookieUtils;
+import com.nimbusds.oauth2.sdk.util.StringUtils;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Component
+public class HttpCookieOAuth2AuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+    public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+    public static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
+    private static final int cookieExpireSeconds = 180;
+
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        return CookieUtils.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+                .map(cookie -> CookieUtils.deserialize(cookie, OAuth2AuthorizationRequest.class))
+                .orElse(null);
+    }
+
+    @Override
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
+        if (authorizationRequest == null) {
+            CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+            CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+            return;
+        }
+
+        CookieUtils.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, CookieUtils.serialize(authorizationRequest), cookieExpireSeconds);
+        String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
+        if (StringUtils.isNotBlank(redirectUriAfterLogin)) {
+            CookieUtils.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin, cookieExpireSeconds);
+        }
+
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request) {
+        return this.loadAuthorizationRequest(request);
+    }
+
+    public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
+        CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+        CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+    }
+}

--- a/src/main/java/com/darknights/devigation/security/token/UserPrincipal.java
+++ b/src/main/java/com/darknights/devigation/security/token/UserPrincipal.java
@@ -5,12 +5,13 @@ import com.darknights.devigation.member.query.application.dto.FindMemberDTO;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import java.util.*;
 
 @Getter
-public class UserPrincipal implements OAuth2User {
+public class UserPrincipal implements OAuth2User, UserDetails {
 
     private final Long id;
     private final String name;
@@ -30,12 +31,16 @@ public class UserPrincipal implements OAuth2User {
         return new Builder(id, name, role, attributes);
     }
 
+    public static Builder builder(Long id, String name, String role) {
+        return new Builder(id, name, role);
+    }
+
     public static class Builder {
         private final Long id;
         private final String name;
         private final String role;
         private final Collection<? extends GrantedAuthority> authorities;
-        private final Map<String, Object> attributes;
+        private Map<String, Object> attributes;
 
         public Builder(Long id, String name, String role, Map<String, Object> attributes) {
             this.id = id;
@@ -43,6 +48,13 @@ public class UserPrincipal implements OAuth2User {
             this.role = role;
             this.authorities = Collections.singletonList(new SimpleGrantedAuthority(role));
             this.attributes = attributes;
+        }
+
+        public Builder(Long id, String name, String role) {
+            this.id = id;
+            this.name = name;
+            this.role = role;
+            this.authorities = Collections.singletonList(new SimpleGrantedAuthority(role));
         }
 
         /**
@@ -64,6 +76,10 @@ public class UserPrincipal implements OAuth2User {
         return UserPrincipal.builder(member.getId(), member.getName(), member.getRole(), attributes).build();
     }
 
+    public static UserPrincipal create(FindMemberDTO member) {
+        return UserPrincipal.builder(member.getId(), member.getName(), member.getRole()).build();
+    }
+
     @Override
     public Map<String, Object> getAttributes() {
         return attributes;
@@ -72,6 +88,36 @@ public class UserPrincipal implements OAuth2User {
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return name;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
     }
 
     @Override

--- a/src/main/java/com/darknights/devigation/security/token/UserPrincipal.java
+++ b/src/main/java/com/darknights/devigation/security/token/UserPrincipal.java
@@ -1,0 +1,81 @@
+package com.darknights.devigation.security.token;
+
+import com.darknights.devigation.member.command.domain.aggregate.entity.Member;
+import com.darknights.devigation.member.query.application.dto.FindMemberDTO;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.*;
+
+@Getter
+public class UserPrincipal implements OAuth2User {
+
+    private final Long id;
+    private final String name;
+    private final String role;
+    private final Collection<? extends GrantedAuthority> authorities;
+    private final Map<String, Object> attributes;
+
+    private UserPrincipal(Builder builder) {
+        this.id = builder.id;
+        this.name = builder.name;
+        this.role = builder.role;
+        this.authorities = builder.authorities;
+        this.attributes = builder.attributes;
+    }
+
+    public static Builder builder(Long id, String name, String role, Map<String, Object> attributes) {
+        return new Builder(id, name, role, attributes);
+    }
+
+    public static class Builder {
+        private final Long id;
+        private final String name;
+        private final String role;
+        private final Collection<? extends GrantedAuthority> authorities;
+        private final Map<String, Object> attributes;
+
+        public Builder(Long id, String name, String role, Map<String, Object> attributes) {
+            this.id = id;
+            this.name = name;
+            this.role = role;
+            this.authorities = Collections.singletonList(new SimpleGrantedAuthority(role));
+            this.attributes = attributes;
+        }
+
+        /**
+         * 위 생성자에서 만약 입력 값 중 옵셔널 값일 경우 Setter를 통해 값을 초기화
+         * 위 경우 Builder 클래스의 옵셔널 필드는 final 키워드 사용 불가
+         * 이러한 경우 Builder 패턴을 사용하는 의미가 크게 낮아짐.
+         */
+
+        public UserPrincipal build() {
+            return new UserPrincipal(this);
+        }
+    }
+
+    public static UserPrincipal create(Member member, Map<String, Object> attributes) {
+        return UserPrincipal.builder(member.getId(), member.getName(), member.getRole().name(), attributes).build();
+    }
+
+    public static UserPrincipal create(FindMemberDTO member, Map<String, Object> attributes) {
+        return UserPrincipal.builder(member.getId(), member.getName(), member.getRole(), attributes).build();
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/resources/mapper/member/MemberMapper.xml
+++ b/src/main/resources/mapper/member/MemberMapper.xml
@@ -11,6 +11,7 @@
         <result property="platform" column="platform"/>
         <result property="role" column="role"/>
         <result property="createdDate" column="created_date"/>
+        <result property="email" column="email"/>
     </resultMap>
 
     <select id="findAll" resultMap="QueryMemberMap">
@@ -43,5 +44,13 @@
             MEMBER_TB
         WHERE
             access_token = #{accessToken}
+    </select>
+
+    <select id="findByEmail" resultMap="QueryMemberMap">
+        SELECT *
+        FROM
+            MEMBER_TB
+        WHERE
+            email = #{email}
     </select>
 </mapper>

--- a/src/test/java/com/darknights/devigation/member/command/application/service/CreateMemberServiceTest.java
+++ b/src/test/java/com/darknights/devigation/member/command/application/service/CreateMemberServiceTest.java
@@ -5,7 +5,6 @@ import com.darknights.devigation.member.command.domain.aggregate.entity.enumType
 import com.darknights.devigation.member.command.domain.aggregate.entity.enumType.Role;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -14,8 +13,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional

--- a/src/test/java/com/darknights/devigation/member/command/application/service/CreateMemberServiceTest.java
+++ b/src/test/java/com/darknights/devigation/member/command/application/service/CreateMemberServiceTest.java
@@ -33,7 +33,6 @@ class CreateMemberServiceTest {
                                 "name1",
                                 Role.MEMBER,
                                 "profileImage",
-                                "accessTokenTest",
                                 PlatformEnum.GITHUB
                         )
                 ),
@@ -43,7 +42,6 @@ class CreateMemberServiceTest {
                                 "name2",
                                 Role.MEMBER,
                                 "profileImage",
-                                "accessTokenTest",
                                 PlatformEnum.GITHUB
                         )
                 )

--- a/src/test/java/com/darknights/devigation/member/command/application/service/CreateMemberServiceTest.java
+++ b/src/test/java/com/darknights/devigation/member/command/application/service/CreateMemberServiceTest.java
@@ -32,6 +32,7 @@ class CreateMemberServiceTest {
                                 "1122ss",
                                 "name1",
                                 Role.MEMBER,
+                                "email@test.com",
                                 "profileImage",
                                 PlatformEnum.GITHUB
                         )
@@ -41,6 +42,7 @@ class CreateMemberServiceTest {
                                 "2211ss",
                                 "name2",
                                 Role.MEMBER,
+                                "email@test.com",
                                 "profileImage",
                                 PlatformEnum.GITHUB
                         )

--- a/src/test/java/com/darknights/devigation/member/query/application/service/FindMemberServiceTest.java
+++ b/src/test/java/com/darknights/devigation/member/query/application/service/FindMemberServiceTest.java
@@ -7,7 +7,6 @@ import com.darknights.devigation.member.command.domain.aggregate.entity.enumType
 import com.darknights.devigation.member.command.domain.aggregate.entity.enumType.Role;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -16,8 +15,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional

--- a/src/test/java/com/darknights/devigation/member/query/application/service/FindMemberServiceTest.java
+++ b/src/test/java/com/darknights/devigation/member/query/application/service/FindMemberServiceTest.java
@@ -36,6 +36,7 @@ class FindMemberServiceTest {
                                 "1122ss",
                                 "name1",
                                 Role.MEMBER,
+                                "email@test.com",
                                 "profileImage",
                                 PlatformEnum.GITHUB
                         )

--- a/src/test/java/com/darknights/devigation/member/query/application/service/FindMemberServiceTest.java
+++ b/src/test/java/com/darknights/devigation/member/query/application/service/FindMemberServiceTest.java
@@ -37,7 +37,6 @@ class FindMemberServiceTest {
                                 "name1",
                                 Role.MEMBER,
                                 "profileImage",
-                                "accessTokenTest",
                                 PlatformEnum.GITHUB
                         )
                 )
@@ -53,13 +52,6 @@ class FindMemberServiceTest {
         Assertions.assertNotNull(findMemberService.findByUID(createMemberDTO.getUID()));
     }
 
-    @DisplayName("Access Token을 통해 생성이 되는지 확인")
-    @ParameterizedTest
-    @MethodSource("getMemberInfo")
-    void findByAccessToken(CreateMemberDTO createMemberDTO) {
-        createMemberService.create(createMemberDTO);
-        Assertions.assertNotNull(findMemberService.findByAccessToken(createMemberDTO.getAccessToken()));
-    }
 
     @DisplayName("Id를 통해 생성이 되는지 확인")
     @ParameterizedTest


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #6 
* #7 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 없음
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* OAuth2와 JWT를 통한 소셜 로그인 토큰 처리 과정
 1. OAuth2 로그인 흐름은 사용자를 엔드포인트 http://localhost:9999/oauth2/authorize/{provider}?redirect_uri=<redirect_uri_after_login>로 전송하여 프런트엔드 클라이언트에서 시작됩니다.

2. 제공자 경로 매개변수는 github 하나입니다. (추후 추가될 수 있습니다.) redirect_uri는 OAuth2 공급자와의 인증이 성공하면 사용자가 리디렉션되는 URI입니다. 이는 OAuth2 redirectUri와 다릅니다.

3. 인증 요청을 수신하면 Spring Security의 OAuth2 클라이언트는 사용자를 제공된 공급자의 AuthorizationUrl로 리디렉션합니다.

4. 인증 요청과 관련된 모든 상태는 SecurityConfig에 지정된 authorizationRequestRepository를 사용하여 저장됩니다.

5. 이제 사용자는 공급자 페이지에서 앱에 대한 권한을 허용/거부합니다. 사용자가 앱에 대한 권한을 허용하면 공급자는 인증 코드와 함께 사용자를 콜백 URL http://localhost:999/oauth2/callback/{provider}로 리디렉션합니다. 사용자가 권한을 거부하면 동일한 callbackUrl로 리디렉션되지만 오류가 발생합니다.

6. OAuth2 콜백에서 오류가 발생하면 Spring 보안은 위의 SecurityConfig에 지정된 oAuth2AuthenticationFailureHandler를 호출합니다.

7. OAuth2 콜백이 성공하고 인증 코드가 포함되어 있으면 Spring Security는 authorization_code를 access_token으로 교환하고 위의 SecurityConfig에 지정된 customOAuth2UserService를 호출합니다.

8. customOAuth2UserService는 인증된 사용자의 세부 정보를 검색하고 데이터베이스에 새 항목을 생성하거나 동일한 id로 기존 항목을 업데이트합니다.

9. 마지막으로 oAuth2AuthenticationSuccessHandler가 호출됩니다. 사용자에 대한 JWT 인증 토큰을 생성하고 쿼리 문자열의 JWT 토큰과 함께 사용자를 redirect_uri로 보냅니다.

```
authorizationEndpoint
: 사용자가 호출하는 클라이언트의 인증 시작 API에 대한 설정입니다. 
사용자가 이 API를 호출하면 소셜로그인 페이지로 사용자를 리다이렉트합니다.

authorizationRequestRepository 
: 사용자의 인증 요청을 임시로 보관하는 리포지토리에 대한 설정입니다. 
이 요청에는 인증 과정을 모두 마친 후 리다이렉트할 프론트의 URI가 담겨있습니다
```


* 깃허브를 통해 사용자의 정보를 가져온 후 JWT 토큰을 발행합니다.
![CleanShot 2023-08-14 at 11 12 16](https://github.com/The-Dark-Nights/back-end/assets/19159759/4a79bbd6-800b-4202-bff8-1e89e643b3c3)
❗️ 발행한 JWT access token의 유효 시간은 2시간입니다. 2시간이 지났을 경우 재로그인을 해야 합니다.

* 클라이언트에서 처리해야 하는 방법은 [[Spring-Boot-Security-OAuth2-JWT](https://github.com/MizzleAa/Spring-Boot-Security-OAuth2-JWT)] 리포지토리의 `frontend/sample` 을 참고해주세요.

* 기존의 소셜 로그인을 통해 가져온 사용자 정보를 서버의 세션에 저장하였지만 클라이언트가 react로 바뀌면서 과정이 수정되었습니다.
기본적으로 Spring OAuth2는 HttpSessionOAuth2AuthorizationRequestRepository를 사용하여 인증 요청을 저장합니다.
그러나 우리 서비스는 상태 비저장이므로 세션에 저장할 수 없습니다.
대신 Base64로 인코딩된 쿠키에 요청을 저장합니다.

``` java
    http
                .cors()
                .and()
                .sessionManagement()
                .sessionCreationPolicy(SessionCreationPolicy.STATELESS) 
                // spring security의 세션 정책을 STATELESS(무상태성)으로 처리합니다.
                ...
```
---

# 관련 스크린샷

![CleanShot 2023-08-14 at 11 11 00](https://github.com/The-Dark-Nights/back-end/assets/19159759/f02a4eb3-6e0b-4617-bd43-732bf6ae7386)


---
* 위 access token을 로컬 스토리지에 저장하는 것은 클라이언트에서 처리한 것입니다.
* 현재 refresh token은 발급하지 않습니다. 추후 작업 내용에 따라 추가할 예정입니다.
---

# 테스트 계획 또는 완료 사항

---
* 없음
