### PR TITLE
[Closes #42] Feature : JWT 토큰 유효성 검사 후 에러 코드 응답

### DIFF
--- a/src/main/java/com/darknights/devigation/DevigationApplication.java
+++ b/src/main/java/com/darknights/devigation/DevigationApplication.java
@@ -6,12 +6,21 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+import javax.annotation.PostConstruct;
+import java.util.TimeZone;
+
 @EnableJpaAuditing
 @SpringBootApplication
 @EnableConfigurationProperties(AppProperties.class)
 public class DevigationApplication {
 
+    @PostConstruct
+    public void started() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
+
     public static void main(String[] args) {
+
         SpringApplication.run(DevigationApplication.class, args);
     }
 

--- a/src/main/java/com/darknights/devigation/common/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/darknights/devigation/common/filter/JwtExceptionFilter.java
@@ -1,0 +1,44 @@
+package com.darknights.devigation.common.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.JwtException;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class JwtExceptionFilter extends OncePerRequestFilter {
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response); // TokenAuthenticationFilter 이동
+        } catch (JwtException ex) {
+            // TokenAuthenticationFilter 예외 발생하면 바로 setErrorResponse 호출
+            System.out.println("setErrorResponse 호출");
+            setErrorResponse(request, response, ex);
+        }
+    }
+
+    private void setErrorResponse(HttpServletRequest request, HttpServletResponse response, JwtException ex) throws IOException {
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        // response 상태 코드를 401로 설정
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        final Map<String, Object> body = new HashMap<>();
+        body.put("status", HttpServletResponse.SC_UNAUTHORIZED);
+        body.put("error", "Unauthorized");
+        // ex.getMessage() 에는 jwtException을 발생시키면서 입력한 메세지가 들어있다.
+        body.put("message", ex.getMessage());
+        body.put("path", request.getServletPath());
+        final ObjectMapper mapper = new ObjectMapper();
+        mapper.writeValue(response.getOutputStream(), body);
+    }
+}

--- a/src/main/java/com/darknights/devigation/common/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/com/darknights/devigation/common/filter/TokenAuthenticationFilter.java
@@ -42,7 +42,8 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }
         } catch (Exception e) {
-            logger.error("Could not set user authentication in security context", e);
+            System.out.println("Could not set user authentication in security context : " + e.getMessage());
+            throw e;
         }
 
         filterChain.doFilter(request, response);

--- a/src/main/java/com/darknights/devigation/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/darknights/devigation/configuration/SecurityConfiguration.java
@@ -1,10 +1,13 @@
 package com.darknights.devigation.configuration;
 
+import com.darknights.devigation.common.filter.JwtExceptionFilter;
+import com.darknights.devigation.common.filter.TokenAuthenticationFilter;
 import com.darknights.devigation.common.handler.CustomOAuth2FailHandler;
 import com.darknights.devigation.common.handler.CustomOAuth2SuccessHandler;
 import com.darknights.devigation.security.command.application.service.CustomOAuth2UserService;
 import com.darknights.devigation.security.command.application.service.RestAuthenticationEntryPoint;
 import com.darknights.devigation.security.command.domain.repository.HttpCookieOAuth2AuthorizationRequestRepository;
+import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -12,6 +15,9 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import javax.servlet.Filter;
 
 @RequiredArgsConstructor
 @EnableWebSecurity
@@ -20,6 +26,8 @@ public class SecurityConfiguration {
     private final CustomOAuth2UserService customOAuth2UserService;
     private final CustomOAuth2SuccessHandler oAuth2AuthenticationSuccessHandler;
     private final CustomOAuth2FailHandler oAuth2AuthenticationFailureHandler;
+    private final TokenAuthenticationFilter tokenAuthenticationFilter;
+    private final JwtExceptionFilter jwtExceptionFilter;
 
     @Bean
     public BCryptPasswordEncoder passwordEncoder() {
@@ -39,6 +47,9 @@ public class SecurityConfiguration {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        http.addFilterBefore(tokenAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(jwtExceptionFilter, tokenAuthenticationFilter.getClass());
 
         http
                 .cors()
@@ -82,4 +93,5 @@ public class SecurityConfiguration {
 
         return http.build();
     }
+
 }

--- a/src/main/java/com/darknights/devigation/security/command/application/service/CustomTokenService.java
+++ b/src/main/java/com/darknights/devigation/security/command/application/service/CustomTokenService.java
@@ -9,6 +9,10 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
 import java.security.Key;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Date;
 
 @Service
@@ -31,7 +35,7 @@ public class CustomTokenService {
         return Jwts.builder()
                 .setSubject(Long.toString(userPrincipal.getId()))
                 .claim("role", userPrincipal.getRole())
-                .setIssuedAt(new Date())
+                .setIssuedAt(now)
                 .setExpiration(expiryDate)
                 .signWith(key,SignatureAlgorithm.HS256)
                 .compact();
@@ -57,15 +61,17 @@ public class CustomTokenService {
             Jwts.parserBuilder().setSigningKey(JWT_SECRET).build().parseClaimsJws(authToken);
             return true;
         } catch (SecurityException | MalformedJwtException ex) {
-            System.out.println("잘못된 JWT 서명입니다.");
+            System.out.println("잘못된 JWT 서명");
+            throw new JwtException("잘못된 JWT 서명");
         } catch (ExpiredJwtException ex) {
-            System.out.println("만료된 JWT 토큰입니다.");
+            throw new JwtException("토큰 기한 만료 (유효 시간 : " + ex.getClaims().getExpiration() + ")");
         } catch (UnsupportedJwtException ex) {
-            System.out.println("지원되지 않는 JWT 토큰입니다.");
+            System.out.println("지원되지 않는 JWT 토큰");
+            throw new JwtException("지원되지 않는 JWT 토큰");
         } catch (IllegalArgumentException ex) {
-            System.out.println("JWT 토큰이 잘못되었습니다.");
+            System.out.println("잘못된 JWT 토큰");
+            throw new JwtException("잘못된 JWT 토큰");
         }
-        return false;
     }
 
 }

--- a/src/main/java/com/darknights/devigation/security/command/application/service/RestAuthenticationEntryPoint.java
+++ b/src/main/java/com/darknights/devigation/security/command/application/service/RestAuthenticationEntryPoint.java
@@ -1,5 +1,7 @@
 package com.darknights.devigation.security.command.application.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 
@@ -7,10 +9,23 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
-        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, authException.getLocalizedMessage());
+        //response.sendError(HttpServletResponse.SC_UNAUTHORIZED, authException.getLocalizedMessage());
+        final Map<String, Object> body = new HashMap<>();
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        // 응답 객체 초기화
+        body.put("status", HttpServletResponse.SC_UNAUTHORIZED);
+        body.put("error", "Unauthorized");
+        body.put("message", authException.getMessage());
+        body.put("path", request.getServletPath());
+        final ObjectMapper mapper = new ObjectMapper();
+        // response 객체에 응답 객체를 넣어줌
+        mapper.writeValue(response.getOutputStream(), body);
+        response.setStatus(HttpServletResponse.SC_OK);
     }
 }


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #42 
---
# 어떤 위험이나 장애가 발견되었는지

---
* JWT 토큰의 유효성 검사 후 응답 상태 코드와 응답 본문을 커스터해야 하는 문제를 해결하였습니다.
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* JWT 유효성 검사 결과에 따라 응답 body의 message가 다르게 출력됩니다.
* JWT 유효성 검사 결과 에러가 발생한 경우 Status code가 401로 설정됩니다.
---

# 관련 스크린샷
- JWT 토큰의 유효시간이 만료될 때
<img width="758" alt="CleanShot 2023-08-15 at 18 11 28@2x" src="https://github.com/The-Dark-Nights/back-end/assets/19159759/44fc7358-f665-4325-945d-a0a6a6892ea0">

- JWT 서명이 로컬로 계산된 서명과 일치하지 않을 경우
<img width="1509" alt="CleanShot 2023-08-15 at 18 11 55@2x" src="https://github.com/The-Dark-Nights/back-end/assets/19159759/35ab576d-e640-4afe-bcd0-1898f5cec21b">

- JWT 토큰의 서명 값이 잘못 입력 될때
<img width="1511" alt="CleanShot 2023-08-15 at 18 13 08@2x" src="https://github.com/The-Dark-Nights/back-end/assets/19159759/31990eae-ed89-40ad-9bd4-9efd334c93b6">


---
* 없음
---

# 테스트 계획 또는 완료 사항

---
* Mvc 목업 테스트로 진행할 예정입니다.