### PR TITLE
[#32] 사진 추가 기능 구현

### DIFF
--- a/src/main/java/com/darknights/devigation/photo/command/application/dto/PhotoDTO.java
+++ b/src/main/java/com/darknights/devigation/photo/command/application/dto/PhotoDTO.java
@@ -1,0 +1,33 @@
+package com.darknights.devigation.photo.command.application.dto;
+
+import com.darknights.devigation.photo.command.domain.aggregate.entity.enumtype.PhotoCategory;
+import lombok.Getter;
+
+@Getter
+public class PhotoDTO {
+
+    private Long id;
+    private Long originId;
+    private String photoName;
+    private String photoRename;
+    private PhotoCategory photoCategory;
+    private String photoRoot;
+
+    public PhotoDTO(Long originId, String photoName, String photoRename, PhotoCategory photoCategory, String photoRoot) {
+        this.originId = originId;
+        this.photoName = photoName;
+        this.photoRename = photoRename;
+        this.photoCategory = photoCategory;
+        this.photoRoot = photoRoot;
+    }
+
+    public PhotoDTO(Long id, Long originId, String photoName, String photoRename, PhotoCategory photoCategory, String photoRoot) {
+        this.id = id;
+        this.originId = originId;
+        this.photoName = photoName;
+        this.photoRename = photoRename;
+        this.photoCategory = photoCategory;
+        this.photoRoot = photoRoot;
+    }
+
+}

--- a/src/main/java/com/darknights/devigation/photo/command/application/service/DeletePhotoService.java
+++ b/src/main/java/com/darknights/devigation/photo/command/application/service/DeletePhotoService.java
@@ -1,0 +1,22 @@
+package com.darknights.devigation.photo.command.application.service;
+
+import com.darknights.devigation.photo.command.domain.repository.PhotoRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+
+// 게시물이 삭제되면서 사진도 삭제해야한다.
+@Service
+public class DeletePhotoService {
+
+    private final PhotoRepository photoRepository;
+
+    @Autowired
+    public DeletePhotoService(PhotoRepository photoRepository){
+        this.photoRepository=photoRepository;
+    }
+
+    public void deletePhoto(Long id){
+        photoRepository.deleteById(id);
+    }
+}

--- a/src/main/java/com/darknights/devigation/photo/command/application/service/InsertPhotoService.java
+++ b/src/main/java/com/darknights/devigation/photo/command/application/service/InsertPhotoService.java
@@ -35,11 +35,11 @@ public class InsertPhotoService {
             return null;
         }
 
-        String savedFolder = "post/";
+        String savedFolder = null;
 
-//        if (category.equals("POST")) {
-//            savedFolder = "post/";
-//        }
+        if (category == PhotoCategory.POST) {
+            savedFolder = "post/";
+        }
 
         File savedFile = null;
 

--- a/src/main/java/com/darknights/devigation/photo/command/application/service/InsertPhotoService.java
+++ b/src/main/java/com/darknights/devigation/photo/command/application/service/InsertPhotoService.java
@@ -1,0 +1,89 @@
+package com.darknights.devigation.photo.command.application.service;
+
+import com.darknights.devigation.photo.command.application.dto.PhotoDTO;
+import com.darknights.devigation.photo.command.domain.aggregate.entity.Photo;
+import com.darknights.devigation.photo.command.domain.repository.PhotoRepository;
+import com.darknights.devigation.photo.command.domain.aggregate.entity.enumtype.PhotoCategory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+public class InsertPhotoService {
+
+    private final PhotoRepository photoRepository;
+
+    @Autowired
+    public InsertPhotoService(PhotoRepository photoRepository) {
+        this.photoRepository = photoRepository;
+    }
+
+    @Value("${custom.path.upload-images}")
+    private String uploadPath;
+
+    @Transactional
+    public PhotoDTO insertPhoto(Long originId, MultipartFile photo,
+                                PhotoCategory category) throws IOException {
+
+        if (photo.isEmpty()) {
+            return null;
+        }
+
+        String savedFolder = "post/";
+
+//        if (category.equals("POST")) {
+//            savedFolder = "post/";
+//        }
+
+        File savedFile = null;
+
+        File photoFolder = new File(uploadPath + savedFolder);
+        System.out.println("photoFolder = " + photoFolder);
+        if (!photoFolder.exists()) {
+            photoFolder.mkdirs();
+        }
+
+        String originPhotoName = photo.getOriginalFilename();
+
+        if (originPhotoName != null) {
+            String ext = originPhotoName.substring(originPhotoName.lastIndexOf("."));
+
+            String savedName = UUID.randomUUID().toString().replace("-", "") + ext;
+
+            String savedPath = "/static/upload-images/" + savedFolder + savedName;
+
+            savedFile =new File(photoFolder,savedName);
+            photo.transferTo(savedFile);
+
+            PhotoDTO photoDTO = new PhotoDTO(originId,originPhotoName,savedName,category,savedPath);
+
+            Photo photoEntity =new Photo(
+                    photoDTO.getOriginId(),
+                    photoDTO.getPhotoCategory(),
+                    photoDTO.getPhotoName(),
+                    photoDTO.getPhotoRename(),
+                    photoDTO.getPhotoRoot()
+            );
+
+            photoRepository.save(photoEntity);
+
+            // DTO타입 반환
+            return new PhotoDTO(
+                    photoEntity.getId(),
+                    photoEntity.getOriginId(),
+                    photoEntity.getPhotoName(),
+                    photoEntity.getPhotoRename(),
+                    photoEntity.getPhotoCategory(),
+                    photoEntity.getPhotoRoot());
+        }
+
+       return null;
+    }
+
+}

--- a/src/main/java/com/darknights/devigation/photo/command/application/service/UpdatePhotoService.java
+++ b/src/main/java/com/darknights/devigation/photo/command/application/service/UpdatePhotoService.java
@@ -1,0 +1,30 @@
+package com.darknights.devigation.photo.command.application.service;
+
+import com.darknights.devigation.photo.command.application.dto.PhotoDTO;
+import com.darknights.devigation.photo.command.domain.aggregate.entity.Photo;
+import com.darknights.devigation.photo.command.domain.aggregate.entity.enumtype.PhotoCategory;
+import com.darknights.devigation.photo.command.domain.repository.PhotoRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Optional;
+
+@Service
+public class UpdatePhotoService {
+
+    private final PhotoRepository photoRepository;
+    private final InsertPhotoService insertPhotoService;
+
+    @Autowired
+    public UpdatePhotoService(PhotoRepository photoRepository, InsertPhotoService insertPhotoService) {
+        this.photoRepository = photoRepository;
+        this.insertPhotoService = insertPhotoService;
+    }
+
+    public PhotoDTO updatePhoto(Long id, Long originId, MultipartFile photo, PhotoCategory category) throws IOException {
+        photoRepository.deleteById(id);
+        return insertPhotoService.insertPhoto(originId, photo, category);
+    }
+}

--- a/src/main/java/com/darknights/devigation/photo/command/domain/aggregate/entity/Photo.java
+++ b/src/main/java/com/darknights/devigation/photo/command/domain/aggregate/entity/Photo.java
@@ -16,7 +16,7 @@ public class Photo {
     private Long id;
 
     @Column(nullable = false)
-    private Long originId;
+    private Long originId;    // 특정 게시물의 ID
 
     @Column(name = "PHOTO_CATEGORY", nullable = false)
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/darknights/devigation/photo/command/domain/aggregate/entity/Photo.java
+++ b/src/main/java/com/darknights/devigation/photo/command/domain/aggregate/entity/Photo.java
@@ -1,17 +1,19 @@
 package com.darknights.devigation.photo.command.domain.aggregate.entity;
 
 import com.darknights.devigation.photo.command.domain.aggregate.entity.enumtype.PhotoCategory;
+import lombok.Getter;
 
 import javax.persistence.*;
 
 @Entity
-@Table(name="PHOTO_TB")
+@Table(name = "PHOTO_TB")
+@Getter
 public class Photo {
 
     @Id
     @Column
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long id;
+    private Long id;
 
     @Column(nullable = false)
     private Long originId;
@@ -22,8 +24,21 @@ public class Photo {
 
     @Column(nullable = false)
     private String photoName;
+
     @Column(nullable = false)
     private String photoRename;
+
     @Column(nullable = false)
     private String photoRoot;
+
+    public Photo() {
+    }
+
+    public Photo(Long originId, PhotoCategory photoCategory, String photoName, String photoRename, String photoRoot) {
+        this.originId = originId;
+        this.photoCategory = photoCategory;
+        this.photoName = photoName;
+        this.photoRename = photoRename;
+        this.photoRoot = photoRoot;
+    }
 }

--- a/src/main/java/com/darknights/devigation/photo/command/domain/repository/PhotoRepository.java
+++ b/src/main/java/com/darknights/devigation/photo/command/domain/repository/PhotoRepository.java
@@ -1,0 +1,7 @@
+package com.darknights.devigation.photo.command.domain.repository;
+
+import com.darknights.devigation.photo.command.domain.aggregate.entity.Photo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PhotoRepository extends JpaRepository<Photo, Long> {
+}

--- a/src/main/java/com/darknights/devigation/post/command/application/dto/UpdatePostDTO.java
+++ b/src/main/java/com/darknights/devigation/post/command/application/dto/UpdatePostDTO.java
@@ -12,10 +12,10 @@ import java.time.LocalDateTime;
 public class UpdatePostDTO {
     private Long id;
     private String title;
-    private Long memberId;
+    private Long memberId;  // 필요 없을 수도 있음
     private Long categoryId;
     private String content;
-    private LocalDateTime createdDate;
+    private LocalDateTime createdDate; // 필요 없을 수도 있음
     private boolean published;
 
     public UpdatePostDTO(Long id, String title, MemberVO memberId, CategoryVO categoryId, String content, LocalDateTime createdDate, boolean published) {

--- a/src/test/java/com/darknights/devigation/photo/command/service/PhotoServiceTests.java
+++ b/src/test/java/com/darknights/devigation/photo/command/service/PhotoServiceTests.java
@@ -1,0 +1,47 @@
+package com.darknights.devigation.photo.command.service;
+
+import com.darknights.devigation.photo.command.application.dto.PhotoDTO;
+import com.darknights.devigation.photo.command.application.service.InsertPhotoService;
+import com.darknights.devigation.photo.command.domain.aggregate.entity.enumtype.PhotoCategory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@SpringBootTest
+@Transactional
+public class PhotoServiceTests {
+
+
+    @Autowired
+    private InsertPhotoService insertPhotoService;
+
+    private MockMvc mvc;
+
+    @DisplayName("사진 업로드 테스트 ")
+    @Test
+    void insertPhotoTest() throws IOException {
+        final String fileName = "testImage1"; //파일명
+        final String contentType = "png"; //파일타입
+
+        MockMultipartFile imgFile = new MockMultipartFile(
+                "images",
+                fileName + "." + contentType, //originalFilename
+                contentType,
+                "images".getBytes(StandardCharsets.UTF_8)
+        );
+        Long originId= 1L;
+        PhotoCategory category= PhotoCategory.POST;
+
+        PhotoDTO resultPhoto=insertPhotoService.insertPhoto(originId,imgFile,category);
+        System.out.println("resultPhoto = " + resultPhoto);
+        Assertions.assertNotNull(resultPhoto);
+    }
+}

--- a/src/test/java/com/darknights/devigation/photo/command/service/PhotoServiceTests.java
+++ b/src/test/java/com/darknights/devigation/photo/command/service/PhotoServiceTests.java
@@ -1,8 +1,11 @@
 package com.darknights.devigation.photo.command.service;
 
 import com.darknights.devigation.photo.command.application.dto.PhotoDTO;
+import com.darknights.devigation.photo.command.application.service.DeletePhotoService;
 import com.darknights.devigation.photo.command.application.service.InsertPhotoService;
+import com.darknights.devigation.photo.command.application.service.UpdatePhotoService;
 import com.darknights.devigation.photo.command.domain.aggregate.entity.enumtype.PhotoCategory;
+import com.darknights.devigation.photo.command.domain.repository.PhotoRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,7 +26,15 @@ public class PhotoServiceTests {
     @Autowired
     private InsertPhotoService insertPhotoService;
 
-    private MockMvc mvc;
+    @Autowired
+    private UpdatePhotoService updatePhotoService;
+
+    @Autowired
+    private DeletePhotoService deletePhotoService;
+
+    @Autowired
+    private PhotoRepository photoRepository;
+
 
     @DisplayName("사진 업로드 테스트 ")
     @Test
@@ -42,6 +53,62 @@ public class PhotoServiceTests {
 
         PhotoDTO resultPhoto=insertPhotoService.insertPhoto(originId,imgFile,category);
         System.out.println("resultPhoto = " + resultPhoto);
+
         Assertions.assertNotNull(resultPhoto);
+    }
+
+    @DisplayName("사진 업데이트 테스트")
+    @Test
+    void updatePhotoTest() throws IOException {
+        final String fileName = "testImage"; //파일명
+        final String contentType = "png"; //파일타입
+
+        MockMultipartFile imgFile = new MockMultipartFile(
+                "images",
+                fileName + "." + contentType, //originalFilename
+                contentType,
+                "images".getBytes(StandardCharsets.UTF_8)
+        );
+        Long originId= 1L;
+        PhotoCategory category= PhotoCategory.POST;
+
+        PhotoDTO beforePhoto=insertPhotoService.insertPhoto(originId,imgFile,category);
+
+
+        final String modifyFileName = "modifyImage"; //파일명
+
+        // 새로운 이미지 파일로 update
+        MockMultipartFile modifyImgFile = new MockMultipartFile(
+                "images",
+                modifyFileName + "." + contentType, //originalFilename
+                contentType,
+                "images".getBytes(StandardCharsets.UTF_8)
+        );
+        
+       PhotoDTO afterPhoto= updatePhotoService.updatePhoto(beforePhoto.getId(), originId,modifyImgFile,category);
+
+       // 다른 이름을 가지고 있는지 확인 => 경로 또한 검증가능하다.
+       Assertions.assertNotEquals(beforePhoto.getPhotoRename(), afterPhoto.getPhotoRename());
+    }
+    @DisplayName("사진 삭제 테스트")
+    @Test
+    void deletePhotoTest() throws IOException {
+        final String fileName = "testImage"; //파일명
+        final String contentType = "png"; //파일타입
+
+        MockMultipartFile imgFile = new MockMultipartFile(
+                "images",
+                fileName + "." + contentType, //originalFilename
+                contentType,
+                "images".getBytes(StandardCharsets.UTF_8)
+        );
+        Long originId= 1L;
+        PhotoCategory category= PhotoCategory.POST;
+
+        PhotoDTO beforePhoto=insertPhotoService.insertPhoto(originId,imgFile,category);
+
+        int deleteBeforeCount= (int) photoRepository.count();
+        deletePhotoService.deletePhoto(beforePhoto.getId());
+        Assertions.assertEquals(photoRepository.count(), deleteBeforeCount-1);
     }
 }


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #32 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 없음
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* OriginId의 역할
![image](https://github.com/The-Dark-Nights/back-end/assets/136034038/c3675f01-eb92-4844-afe5-f807a457bae2)
현재 PhotoEntity의 Column은 위와 같습니다. 여기서 originId란 게시글 ID를 지칭합니다. 현 시점에서 사진 컨텍스트는 게시물 이외에 필요한 부분이 없기도 하고 originId를 게시글의 id를 받아서 사용하게 된다면 한 게시글에 여러 사진을 DB에 등록할 수 있습니다. 

* 수정, 삭제 기능은 originId가 아닌 식별자 id로 수정 삭제를 했습니다.
수정
![image](https://github.com/The-Dark-Nights/back-end/assets/136034038/e6cd56ba-d4e0-43bd-8894-0dd4876e0769)
삭제
![image](https://github.com/The-Dark-Nights/back-end/assets/136034038/b28e2316-2a30-4d24-a5db-0ead3bc03a89)
이렇게 한 이유는 두가지 이유가 있습니다.
첫번째로, 식별자 Id는 조회시 반드시 가지고 있을 수 있는 값일 뿐만 아니라 originId로 할 경우 한 게시물의 여러 사진 중 특정 사진만 삭제하기 어려워질 수 있기 때문입니다.
두번째로, JPA에서 제공하는 findbyId 메소드를 수정없이 바로 사용할 수 있기 때문입니다. 
---

# 관련 스크린샷

---
* 없음
---

# 테스트 계획 또는 완료 사항

---
![image](https://github.com/The-Dark-Nights/back-end/assets/136034038/a65a0fa3-356b-45ca-915e-62cfa4692115)
