### PR TITLE
[Closes #28] Feat : category context Update 기능 작동 방식 수정, Test : 수정한 category Context update test작성

### DIFF
--- a/src/main/java/com/darknights/devigation/category/command/application/service/UpdateCategoryService.java
+++ b/src/main/java/com/darknights/devigation/category/command/application/service/UpdateCategoryService.java
@@ -6,6 +6,10 @@ import com.darknights.devigation.category.command.domain.repository.CategoryRepo
 import com.darknights.devigation.category.command.domain.service.CategoryService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.swing.text.html.Option;
+import java.util.Optional;
 
 @Service
 public class UpdateCategoryService {
@@ -18,7 +22,17 @@ public class UpdateCategoryService {
         this.categoryService = categoryService;
     }
 
-    public Category updateCategory(UpdateCategoryDTO updateCategoryDTO){
-        return categoryRepository.save(categoryService.toCategoryEntity(updateCategoryDTO));
+    @Transactional
+    public boolean updateCategory(UpdateCategoryDTO updateCategoryDTO){
+        Optional<Category> category = categoryRepository.findById(updateCategoryDTO.getId());
+        if(category.isPresent()){
+            Category updateCategory = category.get();
+            if(!updateCategoryDTO.getName().isEmpty()){
+                updateCategory.setName(updateCategoryDTO.getName());
+            }
+            return true;
+        }else{
+            return false;
+        }
     }
 }

--- a/src/test/java/com/darknights/devigation/category/service/CategoryServiceTests.java
+++ b/src/test/java/com/darknights/devigation/category/service/CategoryServiceTests.java
@@ -82,7 +82,7 @@ public class CategoryServiceTests {
         long id = createCategoryService.createCategory(createCategoryDTO).getId();
         if (categoryRepository.findById(id).isPresent()) {
             UpdateCategoryDTO updateCategoryDTO = new UpdateCategoryDTO(id, newName, memberId);
-            Assertions.assertEquals(newName, updateCategoryService.updateCategory(updateCategoryDTO).getName());
+            Assertions.assertTrue(updateCategoryService.updateCategory(updateCategoryDTO));
         }else{
             Assertions.fail();
         }


### PR DESCRIPTION


# 무슨 이유로 코드를 변경했는지

---
* #28
---
# 어떤 위험이나 장애가 발견되었는지

---
* 없음
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* JPA 에서 제공하는 save 함수로 수정하던 방식을 findbyId로 영속성을 가져와 하나의 transaction안에서 setter함수로 수정 처리하도록 코드를 변경하였습니다.
---

# 관련 스크린샷

---
* 없음
---

# 테스트 계획 또는 완료 사항

---
* 
<img width="626" alt="image" src="https://github.com/The-Dark-Nights/back-end/assets/74136791/b9fcb41e-f86e-4d0e-9981-2550edd44fe1">

