### PR TITLE
[#48] Feature : spring security 401, 403 에러 코드 작성

### DIFF
--- a/src/main/java/com/darknights/devigation/admin/command/application/AdminController.java
+++ b/src/main/java/com/darknights/devigation/admin/command/application/AdminController.java
@@ -1,0 +1,16 @@
+package com.darknights.devigation.admin.command.application;
+
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin")
+public class AdminController {
+
+    @GetMapping("/")
+    public String test() {
+        return "test";
+    }
+}

--- a/src/main/java/com/darknights/devigation/common/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/com/darknights/devigation/common/filter/TokenAuthenticationFilter.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;

--- a/src/main/java/com/darknights/devigation/common/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/darknights/devigation/common/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,39 @@
+package com.darknights.devigation.common.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+
+        String requestUrl = "/oauth2/authorize/github";
+        final Map<String, Object> body = new HashMap<>();
+        body.put("status", HttpServletResponse.SC_FORBIDDEN);
+        body.put("error", "FORBIDDEN");
+        body.put("message", "API에 접근할 권한이 없습니다.");
+        body.put("path", request.getServletPath());
+        body.put("request_url", requestUrl);
+        final ObjectMapper mapper = new ObjectMapper();
+        mapper.writeValue(response.getOutputStream(), body);
+        try (OutputStream os = response.getOutputStream()) {
+            ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.writeValue(os, mapper);
+            os.flush();
+        }
+    }
+}

--- a/src/main/java/com/darknights/devigation/member/query/application/service/FindMemberService.java
+++ b/src/main/java/com/darknights/devigation/member/query/application/service/FindMemberService.java
@@ -3,6 +3,7 @@ package com.darknights.devigation.member.query.application.service;
 import com.darknights.devigation.member.query.application.dto.FindMemberDTO;
 import com.darknights.devigation.member.query.domain.aggregate.entity.QueryMember;
 import com.darknights.devigation.member.query.domain.repository.MemberMapper;
+import com.darknights.devigation.security.command.domain.exception.UserNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -43,9 +44,13 @@ public class FindMemberService {
         );
     }
 
-    public FindMemberDTO findById(long memberId) {
+    public FindMemberDTO findById(long memberId) throws UserNotFoundException {
 
         QueryMember findMember = memberMapper.findById(memberId);
+
+        if(findMember == null) {
+            throw new UserNotFoundException("해당 Id를 가진 사용자를 찾을 수 없습니다.");
+        }
 
         return new FindMemberDTO(
                 findMember.getId(),

--- a/src/main/java/com/darknights/devigation/security/command/application/service/CustomTokenService.java
+++ b/src/main/java/com/darknights/devigation/security/command/application/service/CustomTokenService.java
@@ -1,5 +1,6 @@
 package com.darknights.devigation.security.command.application.service;
 
+import com.darknights.devigation.security.command.domain.exception.OAuth2AuthenticationProcessingException;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
@@ -56,15 +57,19 @@ public class CustomTokenService {
             return true;
         } catch (SecurityException | MalformedJwtException ex) {
             System.out.println("잘못된 JWT 서명");
-            throw new JwtException("잘못된 JWT 서명");
+            // throw new JwtException("잘못된 JWT 서명");
+            throw new OAuth2AuthenticationProcessingException("잘못된 JWT 서명", ex.getCause());
         } catch (ExpiredJwtException ex) {
-            throw new JwtException("토큰 기한 만료 (유효 시간 : " + ex.getClaims().getExpiration() + ")");
+            // throw new JwtException("토큰 기한 만료 (유효 시간 : " + ex.getClaims().getExpiration() + ")");
+            throw new OAuth2AuthenticationProcessingException("토큰 기한 만료 (유효 시간 : " + ex.getClaims().getExpiration() + ")", ex.getCause());
         } catch (UnsupportedJwtException ex) {
             System.out.println("지원되지 않는 JWT 토큰");
-            throw new JwtException("지원되지 않는 JWT 토큰");
+            // throw new JwtException("지원되지 않는 JWT 토큰");
+            throw new OAuth2AuthenticationProcessingException("지원되지 않는 JWT 토큰", ex.getCause());
         } catch (IllegalArgumentException ex) {
             System.out.println("잘못된 JWT 토큰");
-            throw new JwtException("잘못된 JWT 토큰");
+            // throw new JwtException("잘못된 JWT 토큰");
+            throw new OAuth2AuthenticationProcessingException("잘못된 JWT 토큰", ex.getCause());
         }
     }
 

--- a/src/main/java/com/darknights/devigation/security/command/application/service/CustomUserDetailService.java
+++ b/src/main/java/com/darknights/devigation/security/command/application/service/CustomUserDetailService.java
@@ -2,6 +2,7 @@ package com.darknights.devigation.security.command.application.service;
 
 import com.darknights.devigation.member.query.application.dto.FindMemberDTO;
 import com.darknights.devigation.member.query.application.service.FindMemberService;
+import com.darknights.devigation.security.command.domain.exception.UserNotFoundException;
 import com.darknights.devigation.security.token.UserPrincipal;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -27,9 +28,9 @@ public class CustomUserDetailService implements UserDetailsService {
         FindMemberDTO member = findMemberService.findByEmail(email);
         return UserPrincipal.create(member);
     }
+
     public UserDetails loadUserById(Long id) {
         FindMemberDTO member = findMemberService.findById(id);
-
         return UserPrincipal.create(member);
     }
 }

--- a/src/main/java/com/darknights/devigation/security/command/domain/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/darknights/devigation/security/command/domain/exception/ResourceNotFoundException.java
@@ -1,31 +1,21 @@
 package com.darknights.devigation.security.command.domain.exception;
 
+import lombok.Getter;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 @ResponseStatus(HttpStatus.NOT_FOUND)
+@Getter
 public class ResourceNotFoundException extends RuntimeException {
 
-    private String resourceName;
-    private String fieldName;
-    private Object fieldValue;
+    private final String resourceName;
+    private final String fieldName;
+    private final Object fieldValue;
 
     public ResourceNotFoundException(String resourceName, String fieldName, Object fieldValue) {
         super(String.format("%s not found with %s : '%s'", resourceName, fieldName, fieldValue));
         this.resourceName = resourceName;
         this.fieldName = fieldName;
         this.fieldValue = fieldValue;
-    }
-
-    public String getResourceName() {
-        return resourceName;
-    }
-
-    public String getFieldName() {
-        return fieldName;
-    }
-
-    public Object getFieldValue() {
-        return fieldValue;
     }
 }

--- a/src/main/java/com/darknights/devigation/security/command/domain/exception/UserNotFoundException.java
+++ b/src/main/java/com/darknights/devigation/security/command/domain/exception/UserNotFoundException.java
@@ -1,0 +1,13 @@
+package com.darknights.devigation.security.command.domain.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class UserNotFoundException extends AuthenticationException {
+    public UserNotFoundException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+
+    public UserNotFoundException(String msg) {
+        super(msg);
+    }
+}


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #48 
---
# 어떤 위험이나 장애가 발견되었는지

---
* API를 요청할 때 JWT 토큰에서 에러가 발생할 경우 응답 에러 본문을 커스텀하였습니다.
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* API를 요청할 때 JWT 토큰에서 에러가 발생할 경우 401, 403 응답 코드를 적용하였습니다.
---

# 관련 스크린샷
- 401 에러

<img width="1335" alt="CleanShot 2023-08-16 at 19 21 52@2x" src="https://github.com/The-Dark-Nights/back-end/assets/19159759/9a80da92-876a-47f6-bb62-45b1a097fb47">
- 403  에러

![CleanShot 2023-08-16 at 20 32 03](https://github.com/The-Dark-Nights/back-end/assets/19159759/8d4ee630-0bbe-42dc-9bb9-bf4bbf5fa3bd)

---
* 없음
---

# 테스트 계획 또는 완료 사항

---
* 테스트 관련 사항을 입력한다.
