### PR TITLE
[#57, #58] Feature : Response Class 구현 및 통합 예외 처리 구현

### DIFF
--- a/src/main/java/com/darknights/devigation/common/advice/AuthControllerAdvice.java
+++ b/src/main/java/com/darknights/devigation/common/advice/AuthControllerAdvice.java
@@ -1,0 +1,56 @@
+package com.darknights.devigation.common.advice;
+
+
+import com.darknights.devigation.common.entity.api.ApiResponse;
+import com.darknights.devigation.common.entity.error.ErrorResponseBody;
+import com.darknights.devigation.common.entity.error.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.time.LocalDateTime;
+
+@RestControllerAdvice
+public class AuthControllerAdvice extends ResponseEntityExceptionHandler {
+    @ExceptionHandler({ AuthenticationException.class })
+    public ResponseEntity<ErrorResponse> handleAuthenticationException(Exception ex) {
+
+        ErrorResponseBody errorResponseBody = new ErrorResponseBody()
+                .setCode(HttpStatus.UNAUTHORIZED.getReasonPhrase())
+                .setClasses(ex.getClass().getSimpleName());
+
+        ApiResponse apiResponse = new ApiResponse()
+                .setStatus(HttpStatus.UNAUTHORIZED.value())
+                .setMessage(ex.getLocalizedMessage())
+                .setTimestamp(LocalDateTime.now());
+
+
+        ErrorResponse errorResponse = new ErrorResponse()
+                .setApiResponse(apiResponse)
+                .setResult(errorResponseBody);
+
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse);
+    }
+
+    @ExceptionHandler({ AccessDeniedException.class })
+    public ResponseEntity<ErrorResponse> handleAccessDeniedException(Exception ex) {
+
+        ErrorResponseBody errorResponseBody = new ErrorResponseBody()
+                .setCode(HttpStatus.FORBIDDEN.getReasonPhrase())
+                .setClasses(ex.getClass().getSimpleName());
+
+        ApiResponse apiResponse = new ApiResponse()
+                .setStatus(HttpStatus.FORBIDDEN.value())
+                .setMessage("API에 접근할 권한이 없습니다.")
+                .setTimestamp(LocalDateTime.now());
+
+        ErrorResponse errorResponse = new ErrorResponse()
+                .setApiResponse(apiResponse)
+                .setResult(errorResponseBody);
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(errorResponse);
+    }
+}

--- a/src/main/java/com/darknights/devigation/common/entity/api/ApiResponse.java
+++ b/src/main/java/com/darknights/devigation/common/entity/api/ApiResponse.java
@@ -1,0 +1,40 @@
+package com.darknights.devigation.common.entity.api;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class ApiResponse {
+    public int status;
+    public String message;
+
+    @JsonFormat(pattern="yyyy-MM-dd HH:mm:ss", timezone="Asia/Seoul")
+    public LocalDateTime timestamp = LocalDateTime.now();
+
+    public ApiResponse() {}
+
+    public ApiResponse(int status, String message, LocalDateTime timestamp) {
+        this.status = status;
+        this.message = message;
+        this.timestamp = timestamp;
+    }
+
+    public ApiResponse setStatus(int status) {
+        this.status = status;
+        return this;
+    }
+
+    public ApiResponse setMessage(String message) {
+        this.message = message;
+        return this;
+    }
+
+    public ApiResponse setTimestamp(LocalDateTime timestamp) {
+        this.timestamp = timestamp;
+        return this;
+    }
+}

--- a/src/main/java/com/darknights/devigation/common/entity/error/ErrorResponse.java
+++ b/src/main/java/com/darknights/devigation/common/entity/error/ErrorResponse.java
@@ -1,0 +1,35 @@
+package com.darknights.devigation.common.entity.error;
+
+import com.darknights.devigation.common.entity.api.ApiResponse;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@JsonPropertyOrder({ "status", "message", "timestamp", "result.*" })
+public class ErrorResponse {
+
+    @JsonUnwrapped // 래핑 해제/평면화 되어야 하는 값을 정의
+    private ApiResponse apiResponse;
+    private ErrorResponseBody result;
+
+    public ErrorResponse() {}
+
+    public ErrorResponse(ApiResponse apiResponse, ErrorResponseBody errorResponseBody) {
+        this.apiResponse = apiResponse;
+        this.result = errorResponseBody;
+    }
+
+    public ErrorResponse setApiResponse(ApiResponse apiResponse) {
+        this.apiResponse = apiResponse;
+        return this;
+    }
+
+    public ErrorResponse setResult(ErrorResponseBody result) {
+        this.result = result;
+        return this;
+    }
+}

--- a/src/main/java/com/darknights/devigation/common/entity/error/ErrorResponseBody.java
+++ b/src/main/java/com/darknights/devigation/common/entity/error/ErrorResponseBody.java
@@ -1,0 +1,30 @@
+package com.darknights.devigation.common.entity.error;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@JsonPropertyOrder({ "code", "classes" })
+public class ErrorResponseBody {
+    private String classes;
+    private String code;
+
+    public ErrorResponseBody() {}
+
+    public ErrorResponseBody(String classes, String code) {
+        this.classes = classes;
+        this.code = code;
+    }
+
+    public ErrorResponseBody setClasses(String classes) {
+        this.classes = classes;
+        return this;
+    }
+
+    public ErrorResponseBody setCode(String code) {
+        this.code = code;
+        return this;
+    }
+}

--- a/src/main/java/com/darknights/devigation/common/filter/AuthenticationExceptionFilter.java
+++ b/src/main/java/com/darknights/devigation/common/filter/AuthenticationExceptionFilter.java
@@ -2,22 +2,28 @@ package com.darknights.devigation.common.filter;
 
 import com.darknights.devigation.security.command.domain.exception.OAuth2AuthenticationProcessingException;
 import com.darknights.devigation.security.command.domain.exception.UserNotFoundException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.springframework.http.MediaType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.HandlerExceptionResolver;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 @Component
 public class AuthenticationExceptionFilter extends OncePerRequestFilter {
+
+    private final HandlerExceptionResolver resolver;
+
+    @Autowired
+    public AuthenticationExceptionFilter(@Qualifier("handlerExceptionResolver")  HandlerExceptionResolver resolver) {
+        this.resolver = resolver;
+    }
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try {
@@ -38,16 +44,18 @@ public class AuthenticationExceptionFilter extends OncePerRequestFilter {
             requestUrl = "추후 access token을 재발생하는 api url";
         }
 
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        // response 상태 코드를 401로 설정
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        final Map<String, Object> body = new HashMap<>();
-        body.put("status", HttpServletResponse.SC_UNAUTHORIZED);
-        body.put("error", "Unauthorized");
-        body.put("request_url", requestUrl);
-        body.put("message", ex.getMessage());
-        body.put("path", request.getServletPath());
-        final ObjectMapper mapper = new ObjectMapper();
-        mapper.writeValue(response.getOutputStream(), body);
+//        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+//        // response 상태 코드를 401로 설정
+//        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+//        final Map<String, Object> body = new HashMap<>();
+//        body.put("status", HttpServletResponse.SC_UNAUTHORIZED);
+//        body.put("error", "Unauthorized");
+//        body.put("request_url", requestUrl);
+//        body.put("message", ex.getMessage());
+//        body.put("path", request.getServletPath());
+//        final ObjectMapper mapper = new ObjectMapper();
+//        mapper.writeValue(response.getOutputStream(), body);
+
+        resolver.resolveException(request, response, null, ex);
     }
 }

--- a/src/main/java/com/darknights/devigation/common/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/darknights/devigation/common/handler/CustomAccessDeniedHandler.java
@@ -1,39 +1,45 @@
 package com.darknights.devigation.common.handler;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.springframework.http.MediaType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerExceptionResolver;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.io.OutputStream;
-import java.util.HashMap;
-import java.util.Map;
 
 @Component
 public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final HandlerExceptionResolver resolver;
+
+    @Autowired
+    public CustomAccessDeniedHandler(@Qualifier("handlerExceptionResolver")  HandlerExceptionResolver resolver) {
+        this.resolver = resolver;
+    }
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-
-        String requestUrl = "/oauth2/authorize/github";
-        final Map<String, Object> body = new HashMap<>();
-        body.put("status", HttpServletResponse.SC_FORBIDDEN);
-        body.put("error", "FORBIDDEN");
-        body.put("message", "API에 접근할 권한이 없습니다.");
-        body.put("path", request.getServletPath());
-        body.put("request_url", requestUrl);
-        final ObjectMapper mapper = new ObjectMapper();
-        mapper.writeValue(response.getOutputStream(), body);
-        try (OutputStream os = response.getOutputStream()) {
-            ObjectMapper objectMapper = new ObjectMapper();
-            objectMapper.writeValue(os, mapper);
-            os.flush();
-        }
+//        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+//        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+//
+//        String requestUrl = "/oauth2/authorize/github";
+//        final Map<String, Object> body = new HashMap<>();
+//        body.put("status", HttpServletResponse.SC_FORBIDDEN);
+//        body.put("error", "FORBIDDEN");
+//        body.put("message", "API에 접근할 권한이 없습니다.");
+//        body.put("path", request.getServletPath());
+//        body.put("request_url", requestUrl);
+//        final ObjectMapper mapper = new ObjectMapper();
+//        mapper.writeValue(response.getOutputStream(), body);
+//        try (OutputStream os = response.getOutputStream()) {
+//            ObjectMapper objectMapper = new ObjectMapper();
+//            objectMapper.writeValue(os, mapper);
+//            os.flush();
+//        }
+        resolver.resolveException(request, response, null, accessDeniedException);
     }
 }

--- a/src/main/java/com/darknights/devigation/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/darknights/devigation/configuration/SecurityConfiguration.java
@@ -7,14 +7,16 @@ import com.darknights.devigation.common.handler.CustomOAuth2FailHandler;
 import com.darknights.devigation.common.handler.CustomOAuth2SuccessHandler;
 import com.darknights.devigation.member.query.domain.aggregate.entity.enumType.Role;
 import com.darknights.devigation.security.command.application.service.CustomOAuth2UserService;
-import com.darknights.devigation.security.command.application.service.RestAuthenticationEntryPoint;
 import com.darknights.devigation.security.command.domain.repository.HttpCookieOAuth2AuthorizationRequestRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -28,6 +30,11 @@ public class SecurityConfiguration {
     private final TokenAuthenticationFilter tokenAuthenticationFilter;
     private final AuthenticationExceptionFilter authenticationExceptionFilter;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
+
+    @Autowired
+    @Qualifier("RestAuthenticationEntryPoint")
+    AuthenticationEntryPoint authEntryPoint;
+
 
     @Bean
     public BCryptPasswordEncoder passwordEncoder() {
@@ -62,7 +69,7 @@ public class SecurityConfiguration {
                 .formLogin()
                 .disable()
                 .exceptionHandling()
-                .authenticationEntryPoint(new RestAuthenticationEntryPoint())
+                .authenticationEntryPoint(authEntryPoint)
                 .and()
 
                 .authorizeRequests()

--- a/src/main/java/com/darknights/devigation/security/command/application/service/RestAuthenticationEntryPoint.java
+++ b/src/main/java/com/darknights/devigation/security/command/application/service/RestAuthenticationEntryPoint.java
@@ -1,31 +1,47 @@
 package com.darknights.devigation.security.command.application.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.springframework.http.MediaType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerExceptionResolver;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
+@Component("RestAuthenticationEntryPoint")
 public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    /*
+    Spring Security Exception
+            (예시, runtime exception에 속하는 AuthenticationException과 AccessDeniedException)들은 핸들링 할 수 없다.
+    DispatcherServlet과 컨트롤러 메소드들이 불러지기 전에 authentication filter에 의해 exception이 던져지기 때문이다.
+    이 같은 exception들을 @ExceptionHandler와 @ControllerAdvice로 핸들링하기 위해서는 AuthenticationEntryPoint를 커스텀해야 한다.
+    */
+    private final HandlerExceptionResolver resolver;
+
+    @Autowired
+    public RestAuthenticationEntryPoint(@Qualifier("handlerExceptionResolver")  HandlerExceptionResolver resolver) {
+        this.resolver = resolver;
+    }
+
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
         //response.sendError(HttpServletResponse.SC_UNAUTHORIZED, authException.getLocalizedMessage());
-        final Map<String, Object> body = new HashMap<>();
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        // 응답 객체 초기화
-        body.put("status", HttpServletResponse.SC_UNAUTHORIZED);
-        body.put("error", "Unauthorized");
-        body.put("message", authException.getMessage());
-        body.put("path", request.getServletPath());
-        final ObjectMapper mapper = new ObjectMapper();
-        // response 객체에 응답 객체를 넣어줌
-        mapper.writeValue(response.getOutputStream(), body);
-        response.setStatus(HttpServletResponse.SC_OK);
+//        final Map<String, Object> body = new HashMap<>();
+//        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+//        // 응답 객체 초기화
+//        body.put("status", HttpServletResponse.SC_UNAUTHORIZED);
+//        body.put("error", "Unauthorized");
+//        body.put("message", authException.getMessage());
+//        body.put("path", request.getServletPath());
+//        final ObjectMapper mapper = new ObjectMapper();
+//        // response 객체에 응답 객체를 넣어줌
+//        mapper.writeValue(response.getOutputStream(), body);
+//        response.setStatus(HttpServletResponse.SC_OK);
+            resolver.resolveException(request, response, null, authException);
     }
 }

--- a/src/test/java/com/darknights/devigation/common/advice/AuthControllerAdviceTest.java
+++ b/src/test/java/com/darknights/devigation/common/advice/AuthControllerAdviceTest.java
@@ -1,0 +1,36 @@
+package com.darknights.devigation.common.advice;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.darknights.devigation.common.entity.error.ErrorResponse;
+import com.darknights.devigation.security.command.application.service.CustomTokenService;
+import com.darknights.devigation.security.command.domain.exception.OAuth2AuthenticationProcessingException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@SpringBootTest
+@Transactional
+class AuthControllerAdviceTest {
+
+    @Autowired
+    private AuthControllerAdvice authControllerAdvice;
+
+    @Autowired
+    private CustomTokenService customTokenService;
+
+    @DisplayName("토큰이 없을 경우 정상적으로 401 상태 코드를 응답하는지 테스트")
+    @Test
+    public void testHandleAuthenticationExceptionReturn401() {
+
+        String token = "";
+
+        OAuth2AuthenticationProcessingException exception = assertThrows(OAuth2AuthenticationProcessingException.class, () -> customTokenService.validateToken(token));
+        ResponseEntity<ErrorResponse> responseEntity = authControllerAdvice.handleAuthenticationException(exception);
+        assertEquals(401, responseEntity.getStatusCodeValue());
+    }
+}


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #57 
* #58 
---
# 어떤 위험이나 장애가 발견되었는지

---
* Exception handler에서 직접 response 객체를 핸들링하여 응답하는 형태에서 저희가 사전에 정의한 ErrorResponse 객체를 응답하도록 수정하였습니다.

---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* `@RestControllerAdvice` 어노테이션을 통해 특정 exception이 발생하면 response 객체를 응답하도록 설정하였습니다.
* `ApiResponse` 객체를 통해 응답 객체를 통일하도록 하였습니다.
* `CustomAccessDeniedHandler` 와 `AuthenticationExceptionFilter` 그리고 `AuthenticationEntryPoint` 에서 `HttpServletResponse` 를 직접 접근하지 않고 `HandlerExceptionResolver` 에 `HttpServletRequest, HttpServletResponse, Object, Exception ` 를 넘겨 `@RestControllerAdvice`에서 처리하도록 구현하였습니다.

---
# 관련 스크린샷
- 업데이트된 401 응답 JSON
<img width="1384" alt="CleanShot 2023-08-18 at 16 07 28@2x" src="https://github.com/The-Dark-Nights/back-end/assets/19159759/c06edec8-7408-4970-b954-10a135589af7">

- 업데이트된 403 응답 JSON
<img width="1383" alt="CleanShot 2023-08-18 at 16 07 15@2x" src="https://github.com/The-Dark-Nights/back-end/assets/19159759/db274b1b-c8a7-468b-ade5-870fd2ca3de5">

---

* [Response Entity And Error Code](https://github.com/The-Dark-Nights/back-end/wiki/Response-Entity-And-Error-Code) 에 관련 내용을 업데이트하였습니다.
---

# 테스트 계획 또는 완료 사항

<img width="1153" alt="CleanShot 2023-08-18 at 18 11 38@2x" src="https://github.com/The-Dark-Nights/back-end/assets/19159759/591c52ff-524e-4d8c-8b1c-0bc566c796e3">

---
* 토큰이 없을 경우 정상적으로 401 상태 코드를 응답하는지 테스트를 완료하였습니다.