### PR TITLE
[Closes #49] Feature : Controller 클래스에서 새로운 access token 발급 API 구현

### DIFF
--- a/src/main/java/com/darknights/devigation/common/advice/AuthControllerAdvice.java
+++ b/src/main/java/com/darknights/devigation/common/advice/AuthControllerAdvice.java
@@ -1,0 +1,56 @@
+package com.darknights.devigation.common.advice;
+
+
+import com.darknights.devigation.common.entity.api.ApiResponse;
+import com.darknights.devigation.common.entity.error.ErrorResponseBody;
+import com.darknights.devigation.common.entity.error.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.time.LocalDateTime;
+
+@RestControllerAdvice
+public class AuthControllerAdvice extends ResponseEntityExceptionHandler {
+    @ExceptionHandler({ AuthenticationException.class })
+    public ResponseEntity<ErrorResponse> handleAuthenticationException(Exception ex) {
+
+        ErrorResponseBody errorResponseBody = new ErrorResponseBody()
+                .setCode(HttpStatus.UNAUTHORIZED.getReasonPhrase())
+                .setClasses(ex.getClass().getSimpleName());
+
+        ApiResponse apiResponse = new ApiResponse()
+                .setStatus(HttpStatus.UNAUTHORIZED.value())
+                .setMessage(ex.getLocalizedMessage())
+                .setTimestamp(LocalDateTime.now());
+
+
+        ErrorResponse errorResponse = new ErrorResponse()
+                .setApiResponse(apiResponse)
+                .setResult(errorResponseBody);
+
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse);
+    }
+
+    @ExceptionHandler({ AccessDeniedException.class })
+    public ResponseEntity<ErrorResponse> handleAccessDeniedException(Exception ex) {
+
+        ErrorResponseBody errorResponseBody = new ErrorResponseBody()
+                .setCode(HttpStatus.FORBIDDEN.getReasonPhrase())
+                .setClasses(ex.getClass().getSimpleName());
+
+        ApiResponse apiResponse = new ApiResponse()
+                .setStatus(HttpStatus.FORBIDDEN.value())
+                .setMessage("API에 접근할 권한이 없습니다.")
+                .setTimestamp(LocalDateTime.now());
+
+        ErrorResponse errorResponse = new ErrorResponse()
+                .setApiResponse(apiResponse)
+                .setResult(errorResponseBody);
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(errorResponse);
+    }
+}

--- a/src/main/java/com/darknights/devigation/common/entity/api/ApiResponse.java
+++ b/src/main/java/com/darknights/devigation/common/entity/api/ApiResponse.java
@@ -1,0 +1,40 @@
+package com.darknights.devigation.common.entity.api;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class ApiResponse {
+    public int status;
+    public String message;
+
+    @JsonFormat(pattern="yyyy-MM-dd HH:mm:ss", timezone="Asia/Seoul")
+    public LocalDateTime timestamp = LocalDateTime.now();
+
+    public ApiResponse() {}
+
+    public ApiResponse(int status, String message, LocalDateTime timestamp) {
+        this.status = status;
+        this.message = message;
+        this.timestamp = timestamp;
+    }
+
+    public ApiResponse setStatus(int status) {
+        this.status = status;
+        return this;
+    }
+
+    public ApiResponse setMessage(String message) {
+        this.message = message;
+        return this;
+    }
+
+    public ApiResponse setTimestamp(LocalDateTime timestamp) {
+        this.timestamp = timestamp;
+        return this;
+    }
+}

--- a/src/main/java/com/darknights/devigation/common/entity/error/ErrorResponse.java
+++ b/src/main/java/com/darknights/devigation/common/entity/error/ErrorResponse.java
@@ -1,0 +1,35 @@
+package com.darknights.devigation.common.entity.error;
+
+import com.darknights.devigation.common.entity.api.ApiResponse;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@JsonPropertyOrder({ "status", "message", "timestamp", "result.*" })
+public class ErrorResponse {
+
+    @JsonUnwrapped // 래핑 해제/평면화 되어야 하는 값을 정의
+    private ApiResponse apiResponse;
+    private ErrorResponseBody result;
+
+    public ErrorResponse() {}
+
+    public ErrorResponse(ApiResponse apiResponse, ErrorResponseBody errorResponseBody) {
+        this.apiResponse = apiResponse;
+        this.result = errorResponseBody;
+    }
+
+    public ErrorResponse setApiResponse(ApiResponse apiResponse) {
+        this.apiResponse = apiResponse;
+        return this;
+    }
+
+    public ErrorResponse setResult(ErrorResponseBody result) {
+        this.result = result;
+        return this;
+    }
+}

--- a/src/main/java/com/darknights/devigation/common/entity/error/ErrorResponseBody.java
+++ b/src/main/java/com/darknights/devigation/common/entity/error/ErrorResponseBody.java
@@ -1,0 +1,30 @@
+package com.darknights.devigation.common.entity.error;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@JsonPropertyOrder({ "code", "classes" })
+public class ErrorResponseBody {
+    private String classes;
+    private String code;
+
+    public ErrorResponseBody() {}
+
+    public ErrorResponseBody(String classes, String code) {
+        this.classes = classes;
+        this.code = code;
+    }
+
+    public ErrorResponseBody setClasses(String classes) {
+        this.classes = classes;
+        return this;
+    }
+
+    public ErrorResponseBody setCode(String code) {
+        this.code = code;
+        return this;
+    }
+}

--- a/src/main/java/com/darknights/devigation/common/filter/AuthenticationExceptionFilter.java
+++ b/src/main/java/com/darknights/devigation/common/filter/AuthenticationExceptionFilter.java
@@ -2,22 +2,28 @@ package com.darknights.devigation.common.filter;
 
 import com.darknights.devigation.security.command.domain.exception.OAuth2AuthenticationProcessingException;
 import com.darknights.devigation.security.command.domain.exception.UserNotFoundException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.springframework.http.MediaType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.HandlerExceptionResolver;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 @Component
 public class AuthenticationExceptionFilter extends OncePerRequestFilter {
+
+    private final HandlerExceptionResolver resolver;
+
+    @Autowired
+    public AuthenticationExceptionFilter(@Qualifier("handlerExceptionResolver")  HandlerExceptionResolver resolver) {
+        this.resolver = resolver;
+    }
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try {
@@ -38,16 +44,18 @@ public class AuthenticationExceptionFilter extends OncePerRequestFilter {
             requestUrl = "추후 access token을 재발생하는 api url";
         }
 
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        // response 상태 코드를 401로 설정
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        final Map<String, Object> body = new HashMap<>();
-        body.put("status", HttpServletResponse.SC_UNAUTHORIZED);
-        body.put("error", "Unauthorized");
-        body.put("request_url", requestUrl);
-        body.put("message", ex.getMessage());
-        body.put("path", request.getServletPath());
-        final ObjectMapper mapper = new ObjectMapper();
-        mapper.writeValue(response.getOutputStream(), body);
+//        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+//        // response 상태 코드를 401로 설정
+//        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+//        final Map<String, Object> body = new HashMap<>();
+//        body.put("status", HttpServletResponse.SC_UNAUTHORIZED);
+//        body.put("error", "Unauthorized");
+//        body.put("request_url", requestUrl);
+//        body.put("message", ex.getMessage());
+//        body.put("path", request.getServletPath());
+//        final ObjectMapper mapper = new ObjectMapper();
+//        mapper.writeValue(response.getOutputStream(), body);
+
+        resolver.resolveException(request, response, null, ex);
     }
 }

--- a/src/main/java/com/darknights/devigation/common/filter/AuthenticationExceptionFilter.java
+++ b/src/main/java/com/darknights/devigation/common/filter/AuthenticationExceptionFilter.java
@@ -1,11 +1,8 @@
 package com.darknights.devigation.common.filter;
 
-import com.darknights.devigation.security.command.domain.exception.OAuth2AuthenticationProcessingException;
-import com.darknights.devigation.security.command.domain.exception.UserNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 
@@ -15,7 +12,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
-@Component
 public class AuthenticationExceptionFilter extends OncePerRequestFilter {
 
     private final HandlerExceptionResolver resolver;
@@ -37,12 +33,12 @@ public class AuthenticationExceptionFilter extends OncePerRequestFilter {
 
     private void setErrorResponse(HttpServletRequest request, HttpServletResponse response, AuthenticationException ex) throws IOException {
 
-        String requestUrl = null;
-        if(ex.getClass() == UserNotFoundException.class) {
-            requestUrl = "/oauth2/authorize/github";
-        } else if (ex.getClass() == OAuth2AuthenticationProcessingException.class) {
-            requestUrl = "추후 access token을 재발생하는 api url";
-        }
+//        String requestUrl = null;
+//        if(ex.getClass() == UserNotFoundException.class) {
+//            requestUrl = "/oauth2/authorize/github";
+//        } else if (ex.getClass() == OAuth2AuthenticationProcessingException.class) {
+//            requestUrl = "추후 access token을 재발생하는 api url";
+//        }
 
 //        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 //        // response 상태 코드를 401로 설정

--- a/src/main/java/com/darknights/devigation/common/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/com/darknights/devigation/common/filter/TokenAuthenticationFilter.java
@@ -1,14 +1,11 @@
 package com.darknights.devigation.common.filter;
 
 import com.darknights.devigation.security.command.application.service.CustomUserDetailService;
-import com.darknights.devigation.security.command.application.service.CustomTokenService;
-import org.springframework.beans.factory.annotation.Autowired;
+import com.darknights.devigation.security.command.domain.service.CustomTokenService;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
-import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -18,18 +15,17 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
-@Component
 public class TokenAuthenticationFilter extends OncePerRequestFilter {
 
     private final CustomTokenService customTokenService;
 
     private final CustomUserDetailService customUserDetailService;
 
-    @Autowired
     public TokenAuthenticationFilter(CustomTokenService customTokenService, CustomUserDetailService customUserDetailService) {
         this.customTokenService = customTokenService;
         this.customUserDetailService = customUserDetailService;
     }
+
 
 
     @Override
@@ -56,7 +52,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     private String getJwtFromRequest(HttpServletRequest request) {
         String bearerToken = request.getHeader("Authorization");
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
-            return bearerToken.substring(7, bearerToken.length());
+            return bearerToken.substring(7);
         }
         return null;
     }

--- a/src/main/java/com/darknights/devigation/common/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/darknights/devigation/common/handler/CustomAccessDeniedHandler.java
@@ -1,39 +1,45 @@
 package com.darknights.devigation.common.handler;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.springframework.http.MediaType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerExceptionResolver;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.io.OutputStream;
-import java.util.HashMap;
-import java.util.Map;
 
 @Component
 public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final HandlerExceptionResolver resolver;
+
+    @Autowired
+    public CustomAccessDeniedHandler(@Qualifier("handlerExceptionResolver")  HandlerExceptionResolver resolver) {
+        this.resolver = resolver;
+    }
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-
-        String requestUrl = "/oauth2/authorize/github";
-        final Map<String, Object> body = new HashMap<>();
-        body.put("status", HttpServletResponse.SC_FORBIDDEN);
-        body.put("error", "FORBIDDEN");
-        body.put("message", "API에 접근할 권한이 없습니다.");
-        body.put("path", request.getServletPath());
-        body.put("request_url", requestUrl);
-        final ObjectMapper mapper = new ObjectMapper();
-        mapper.writeValue(response.getOutputStream(), body);
-        try (OutputStream os = response.getOutputStream()) {
-            ObjectMapper objectMapper = new ObjectMapper();
-            objectMapper.writeValue(os, mapper);
-            os.flush();
-        }
+//        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+//        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+//
+//        String requestUrl = "/oauth2/authorize/github";
+//        final Map<String, Object> body = new HashMap<>();
+//        body.put("status", HttpServletResponse.SC_FORBIDDEN);
+//        body.put("error", "FORBIDDEN");
+//        body.put("message", "API에 접근할 권한이 없습니다.");
+//        body.put("path", request.getServletPath());
+//        body.put("request_url", requestUrl);
+//        final ObjectMapper mapper = new ObjectMapper();
+//        mapper.writeValue(response.getOutputStream(), body);
+//        try (OutputStream os = response.getOutputStream()) {
+//            ObjectMapper objectMapper = new ObjectMapper();
+//            objectMapper.writeValue(os, mapper);
+//            os.flush();
+//        }
+        resolver.resolveException(request, response, null, accessDeniedException);
     }
 }

--- a/src/main/java/com/darknights/devigation/common/handler/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/darknights/devigation/common/handler/CustomOAuth2SuccessHandler.java
@@ -2,7 +2,7 @@ package com.darknights.devigation.common.handler;
 
 
 import com.darknights.devigation.configuration.AppProperties;
-import com.darknights.devigation.security.command.application.service.CustomTokenService;
+import com.darknights.devigation.security.command.application.service.IssueTokenService;
 import com.darknights.devigation.security.command.domain.aggregate.util.CookieUtils;
 import com.darknights.devigation.security.command.domain.exception.BadRequestException;
 import com.darknights.devigation.security.command.domain.repository.HttpCookieOAuth2AuthorizationRequestRepository;
@@ -28,16 +28,16 @@ import static com.darknights.devigation.security.command.domain.repository.HttpC
 @Component
 public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
-    private final CustomTokenService customTokenService;
+    private final IssueTokenService issueTokenService;
 
     private final AppProperties appProperties;
 
     private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
 
     @Autowired
-    CustomOAuth2SuccessHandler(CustomTokenService customTokenService, AppProperties appProperties,
+    CustomOAuth2SuccessHandler(IssueTokenService issueTokenService, AppProperties appProperties,
                                HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository) {
-        this.customTokenService = customTokenService;
+        this.issueTokenService = issueTokenService;
         this.appProperties = appProperties;
         this.httpCookieOAuth2AuthorizationRequestRepository = httpCookieOAuth2AuthorizationRequestRepository;
     }
@@ -68,7 +68,7 @@ public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHa
 
         UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();
 
-        String token = customTokenService.createToken(userPrincipal.getId(), userPrincipal.getRole());
+        String token = issueTokenService.issueTokenByUserPrincipal(userPrincipal);
 
         return UriComponentsBuilder.fromUriString(targetUrl)
                 .queryParam("token", token)

--- a/src/main/java/com/darknights/devigation/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/darknights/devigation/configuration/SecurityConfiguration.java
@@ -7,14 +7,16 @@ import com.darknights.devigation.common.handler.CustomOAuth2FailHandler;
 import com.darknights.devigation.common.handler.CustomOAuth2SuccessHandler;
 import com.darknights.devigation.member.query.domain.aggregate.entity.enumType.Role;
 import com.darknights.devigation.security.command.application.service.CustomOAuth2UserService;
-import com.darknights.devigation.security.command.application.service.RestAuthenticationEntryPoint;
 import com.darknights.devigation.security.command.domain.repository.HttpCookieOAuth2AuthorizationRequestRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -28,6 +30,11 @@ public class SecurityConfiguration {
     private final TokenAuthenticationFilter tokenAuthenticationFilter;
     private final AuthenticationExceptionFilter authenticationExceptionFilter;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
+
+    @Autowired
+    @Qualifier("RestAuthenticationEntryPoint")
+    AuthenticationEntryPoint authEntryPoint;
+
 
     @Bean
     public BCryptPasswordEncoder passwordEncoder() {
@@ -62,7 +69,7 @@ public class SecurityConfiguration {
                 .formLogin()
                 .disable()
                 .exceptionHandling()
-                .authenticationEntryPoint(new RestAuthenticationEntryPoint())
+                .authenticationEntryPoint(authEntryPoint)
                 .and()
 
                 .authorizeRequests()

--- a/src/main/java/com/darknights/devigation/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/darknights/devigation/configuration/SecurityConfiguration.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
@@ -67,25 +68,54 @@ public class SecurityConfiguration {
     }
 
 
+//    @Bean
+//    public WebSecurityCustomizer webSecurityCustomizer(){
+//        return web -> {
+//            web.ignoring()
+//                    .antMatchers(
+//                            "/", "/error","/favicon.ico", "/**/*.png",
+//                            "/**/*.gif", "/**/*.svg", "/**/*.jpg",
+//                            "/**/*.html", "/**/*.css", "/**/*.js"
+//                            )
+//                    .antMatchers(
+//                            "/swagger", "/swagger-ui.html", "/swagger-ui/**",
+//                            "/api-docs", "/api-docs/**", "/v3/api-docs/**"
+//                    )
+//                    .antMatchers(
+//                            "/login/**","/auth/**"
+//                    );
+//        };
+
+
     @Bean
-    public WebSecurityCustomizer webSecurityCustomizer(){
-        return web -> {
-            web.ignoring()
-                    .antMatchers(
+    @Order(0)
+    public SecurityFilterChain exceptionSecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .requestMatchers((matchers) ->
+                        matchers
+                                .antMatchers(
                             "/", "/error","/favicon.ico", "/**/*.png",
                             "/**/*.gif", "/**/*.svg", "/**/*.jpg",
                             "/**/*.html", "/**/*.css", "/**/*.js"
                             )
-                    .antMatchers(
+                            .antMatchers(
                             "/swagger", "/swagger-ui.html", "/swagger-ui/**",
                             "/api-docs", "/api-docs/**", "/v3/api-docs/**"
-                    )
-                    .antMatchers(
-                            "/login/**","/auth/**", "/oauth2/**"
-                    );
-        };
+                            )
+                            .antMatchers(
+                                "/login/**","/auth/**"
+                            )
+                )
+                .authorizeHttpRequests((authorize) -> authorize.anyRequest().permitAll())
+                .csrf().disable()
+                .requestCache().disable()
+                .securityContext().disable()
+                .sessionManagement().disable();
+
+        return http.build();
     }
     @Bean
+    @Order(1)
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
         http
@@ -103,6 +133,8 @@ public class SecurityConfiguration {
                 .and()
 
                 .authorizeRequests()
+                    .antMatchers("/oauth2/**")
+                        .permitAll()
                     .antMatchers("/blog/**")
                         .permitAll()
                     .antMatchers("/admin/**")

--- a/src/main/java/com/darknights/devigation/member/command/domain/aggregate/entity/Member.java
+++ b/src/main/java/com/darknights/devigation/member/command/domain/aggregate/entity/Member.java
@@ -21,9 +21,6 @@ public class Member {
     @Column(length = 100, nullable = false)
     private String name;
 
-    @Column(nullable = true, name = "access_token")
-    private String accessToken;
-
     @Column(nullable = false, name = "email", unique = true)
     private String email;
 
@@ -45,7 +42,7 @@ public class Member {
     @Column(name = "created_date", nullable = false)
     private LocalDateTime createdDate;
 
-    protected Member() {};
+    protected Member() {}
 
     public Member(String name, String UID, String profileImage, String email ,PlatformEnum platform, Role role) {
         this.name = name;

--- a/src/main/java/com/darknights/devigation/security/command/application/controller/AuthController.java
+++ b/src/main/java/com/darknights/devigation/security/command/application/controller/AuthController.java
@@ -1,0 +1,51 @@
+package com.darknights.devigation.security.command.application.controller;
+
+
+import com.darknights.devigation.common.entity.api.ApiResponse;
+import com.darknights.devigation.security.command.application.dto.AuthResponse;
+import com.darknights.devigation.security.command.application.dto.AuthResponseBody;
+import com.darknights.devigation.security.command.application.service.IssueTokenService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.time.LocalDateTime;
+
+@Controller
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final IssueTokenService issueTokenService;
+
+    @Autowired
+    public AuthController(IssueTokenService issueTokenService) {
+        this.issueTokenService = issueTokenService;
+    }
+
+    @PostMapping("token")
+    public ResponseEntity<?> issueToken (@RequestHeader(HttpHeaders.AUTHORIZATION) String bearerToken) {
+
+        String accessToken =  bearerToken.substring(7);
+
+        String issuedToken = issueTokenService.issueTokenByAccessToken(accessToken);
+
+        ApiResponse apiResponse = new ApiResponse()
+                .setStatus(HttpStatus.FORBIDDEN.value())
+                .setMessage("새로운 Access Token을 발급했습니다.")
+                .setTimestamp(LocalDateTime.now());
+
+
+        AuthResponseBody authResponseBody = new AuthResponseBody()
+                .setAccessToken(issuedToken);
+
+        AuthResponse authResponse = new AuthResponse()
+                .setApiResponse(apiResponse)
+                .setBody(authResponseBody);
+        return ResponseEntity.status(HttpStatus.CREATED).body(authResponse);
+    }
+}

--- a/src/main/java/com/darknights/devigation/security/command/application/controller/AuthController.java
+++ b/src/main/java/com/darknights/devigation/security/command/application/controller/AuthController.java
@@ -35,7 +35,7 @@ public class AuthController {
         String issuedToken = issueTokenService.issueTokenByAccessToken(accessToken);
 
         ApiResponse apiResponse = new ApiResponse()
-                .setStatus(HttpStatus.FORBIDDEN.value())
+                .setStatus(HttpStatus.CREATED.value())
                 .setMessage("새로운 Access Token을 발급했습니다.")
                 .setTimestamp(LocalDateTime.now());
 

--- a/src/main/java/com/darknights/devigation/security/command/application/dto/AuthResponse.java
+++ b/src/main/java/com/darknights/devigation/security/command/application/dto/AuthResponse.java
@@ -1,0 +1,30 @@
+package com.darknights.devigation.security.command.application.dto;
+
+import com.darknights.devigation.common.entity.api.ApiResponse;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@JsonPropertyOrder({ "status", "message", "timestamp", "body.*" })
+public class AuthResponse {
+
+    @JsonUnwrapped // 래핑 해제/평면화 되어야 하는 값을 정의
+    private ApiResponse apiResponse;
+    private AuthResponseBody body;
+
+    public AuthResponse() {}
+
+
+    public AuthResponse setApiResponse(ApiResponse apiResponse) {
+        this.apiResponse = apiResponse;
+        return this;
+    }
+
+    public AuthResponse setBody(AuthResponseBody body) {
+        this.body = body;
+        return this;
+    }
+}

--- a/src/main/java/com/darknights/devigation/security/command/application/dto/AuthResponseBody.java
+++ b/src/main/java/com/darknights/devigation/security/command/application/dto/AuthResponseBody.java
@@ -1,0 +1,17 @@
+package com.darknights.devigation.security.command.application.dto;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class AuthResponseBody {
+    private String accessToken;
+
+    public AuthResponseBody() {}
+
+    public AuthResponseBody setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+        return this;
+    }
+}

--- a/src/main/java/com/darknights/devigation/security/command/application/dto/RefreshAccessTokenDTO.java
+++ b/src/main/java/com/darknights/devigation/security/command/application/dto/RefreshAccessTokenDTO.java
@@ -1,0 +1,14 @@
+package com.darknights.devigation.security.command.application.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class RefreshAccessTokenDTO {
+    private String accessToken;
+
+    public RefreshAccessTokenDTO(String accessToken) {
+        this.accessToken = accessToken;
+    }
+}

--- a/src/main/java/com/darknights/devigation/security/command/application/service/IssueTokenService.java
+++ b/src/main/java/com/darknights/devigation/security/command/application/service/IssueTokenService.java
@@ -1,0 +1,63 @@
+package com.darknights.devigation.security.command.application.service;
+
+import com.darknights.devigation.member.query.application.dto.FindMemberDTO;
+import com.darknights.devigation.security.command.domain.aggregate.entity.Token;
+import com.darknights.devigation.security.command.domain.aggregate.vo.MemberVO;
+import com.darknights.devigation.security.command.domain.repository.TokenRepository;
+import com.darknights.devigation.security.command.domain.service.CustomTokenService;
+import com.darknights.devigation.security.command.domain.service.RequestMember;
+import com.darknights.devigation.security.token.UserPrincipal;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+
+@Service
+public class IssueTokenService {
+
+    private final CustomTokenService customTokenService;
+    private final TokenRepository tokenRepository;
+    private final RequestMember requestMember;
+
+    @Autowired
+    public IssueTokenService(CustomTokenService customTokenService, TokenRepository tokenRepository, RequestMember requestMember) {
+        this.customTokenService = customTokenService;
+        this.tokenRepository = tokenRepository;
+        this.requestMember = requestMember;
+    }
+
+    @Transactional
+    public String issueTokenByUserPrincipal(UserPrincipal userPrincipal) {
+        long memberId = userPrincipal.getId();
+        String memberRole = userPrincipal.getRole();
+        Optional<Token> findToken = tokenRepository.findTokenByMember_Id(memberId);
+        String issuedToken = customTokenService.createToken(memberId, memberRole);
+        if (findToken.isPresent()) {
+            Token updateToken = findToken.get();
+            updateToken.setAccessToken(issuedToken);
+            tokenRepository.save(updateToken);
+        } else {
+            Token createdToken = new Token(new MemberVO(memberId), issuedToken);
+            tokenRepository.save(createdToken);
+        }
+        return issuedToken;
+    }
+
+    @Transactional
+    public String issueTokenByAccessToken(String accessToken) {
+        Token findToken = tokenRepository.findTokenByAccessToken(accessToken).orElseThrow(
+                () -> new IllegalArgumentException("Can't find data")
+        );
+        long memberId = findToken.getMember().getId();
+
+        FindMemberDTO findMember = requestMember.getMemberById(memberId);
+
+        String issuedToken = customTokenService.createToken(findMember.getId(), findMember.getRole());
+        findToken.setAccessToken(issuedToken);
+        tokenRepository.save(findToken);
+
+        return issuedToken;
+    }
+}

--- a/src/main/java/com/darknights/devigation/security/command/application/service/RestAuthenticationEntryPoint.java
+++ b/src/main/java/com/darknights/devigation/security/command/application/service/RestAuthenticationEntryPoint.java
@@ -1,31 +1,47 @@
 package com.darknights.devigation.security.command.application.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.springframework.http.MediaType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerExceptionResolver;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
+@Component("RestAuthenticationEntryPoint")
 public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    /*
+    Spring Security Exception
+            (예시, runtime exception에 속하는 AuthenticationException과 AccessDeniedException)들은 핸들링 할 수 없다.
+    DispatcherServlet과 컨트롤러 메소드들이 불러지기 전에 authentication filter에 의해 exception이 던져지기 때문이다.
+    이 같은 exception들을 @ExceptionHandler와 @ControllerAdvice로 핸들링하기 위해서는 AuthenticationEntryPoint를 커스텀해야 한다.
+    */
+    private final HandlerExceptionResolver resolver;
+
+    @Autowired
+    public RestAuthenticationEntryPoint(@Qualifier("handlerExceptionResolver")  HandlerExceptionResolver resolver) {
+        this.resolver = resolver;
+    }
+
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
         //response.sendError(HttpServletResponse.SC_UNAUTHORIZED, authException.getLocalizedMessage());
-        final Map<String, Object> body = new HashMap<>();
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        // 응답 객체 초기화
-        body.put("status", HttpServletResponse.SC_UNAUTHORIZED);
-        body.put("error", "Unauthorized");
-        body.put("message", authException.getMessage());
-        body.put("path", request.getServletPath());
-        final ObjectMapper mapper = new ObjectMapper();
-        // response 객체에 응답 객체를 넣어줌
-        mapper.writeValue(response.getOutputStream(), body);
-        response.setStatus(HttpServletResponse.SC_OK);
+//        final Map<String, Object> body = new HashMap<>();
+//        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+//        // 응답 객체 초기화
+//        body.put("status", HttpServletResponse.SC_UNAUTHORIZED);
+//        body.put("error", "Unauthorized");
+//        body.put("message", authException.getMessage());
+//        body.put("path", request.getServletPath());
+//        final ObjectMapper mapper = new ObjectMapper();
+//        // response 객체에 응답 객체를 넣어줌
+//        mapper.writeValue(response.getOutputStream(), body);
+//        response.setStatus(HttpServletResponse.SC_OK);
+            resolver.resolveException(request, response, null, authException);
     }
 }

--- a/src/main/java/com/darknights/devigation/security/command/domain/aggregate/entity/Token.java
+++ b/src/main/java/com/darknights/devigation/security/command/domain/aggregate/entity/Token.java
@@ -1,0 +1,34 @@
+package com.darknights.devigation.security.command.domain.aggregate.entity;
+
+
+import com.darknights.devigation.security.command.domain.aggregate.vo.MemberVO;
+import lombok.Getter;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "TOKEN_TB")
+@Getter
+public class Token {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Embedded
+    private MemberVO member;
+
+    @Column(length = 1024, nullable = false, name = "access_token")
+    private String accessToken;
+
+    protected Token() {}
+
+    public Token(MemberVO member, String accessToken) {
+        this.member = member;
+        this.accessToken = accessToken;
+    }
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+}

--- a/src/main/java/com/darknights/devigation/security/command/domain/aggregate/vo/MemberVO.java
+++ b/src/main/java/com/darknights/devigation/security/command/domain/aggregate/vo/MemberVO.java
@@ -1,0 +1,20 @@
+package com.darknights.devigation.security.command.domain.aggregate.vo;
+
+
+import lombok.Getter;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+@Getter
+@Embeddable
+public class MemberVO {
+    @Column(nullable = false, name = "member_id")
+    private long id;
+
+    public MemberVO(long id) {
+        this.id = id;
+    }
+
+    protected MemberVO() {}
+}

--- a/src/main/java/com/darknights/devigation/security/command/domain/repository/TokenRepository.java
+++ b/src/main/java/com/darknights/devigation/security/command/domain/repository/TokenRepository.java
@@ -1,0 +1,14 @@
+package com.darknights.devigation.security.command.domain.repository;
+
+import com.darknights.devigation.security.command.domain.aggregate.entity.Token;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface TokenRepository extends JpaRepository<Token, Long> {
+
+    Optional<Token> findTokenByMember_Id(long memberId);
+    Optional<Token> findTokenByAccessToken(String accessToken);
+}

--- a/src/main/java/com/darknights/devigation/security/command/domain/service/CustomTokenService.java
+++ b/src/main/java/com/darknights/devigation/security/command/domain/service/CustomTokenService.java
@@ -1,16 +1,16 @@
-package com.darknights.devigation.security.command.application.service;
+package com.darknights.devigation.security.command.domain.service;
 
+import com.darknights.devigation.common.annotation.DomainService;
 import com.darknights.devigation.security.command.domain.exception.OAuth2AuthenticationProcessingException;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
 
 import java.security.Key;
 import java.util.Date;
 
-@Service
+@DomainService
 public class CustomTokenService {
 
     @Value("${app.auth.tokenSecret}")

--- a/src/main/java/com/darknights/devigation/security/command/domain/service/RequestMember.java
+++ b/src/main/java/com/darknights/devigation/security/command/domain/service/RequestMember.java
@@ -1,0 +1,7 @@
+package com.darknights.devigation.security.command.domain.service;
+
+import com.darknights.devigation.member.query.application.dto.FindMemberDTO;
+
+public interface RequestMember {
+    FindMemberDTO getMemberById(long memberId);
+}

--- a/src/main/java/com/darknights/devigation/security/command/infra/service/RequestMemberService.java
+++ b/src/main/java/com/darknights/devigation/security/command/infra/service/RequestMemberService.java
@@ -1,0 +1,24 @@
+package com.darknights.devigation.security.command.infra.service;
+
+
+import com.darknights.devigation.common.annotation.InfraService;
+import com.darknights.devigation.member.query.application.dto.FindMemberDTO;
+import com.darknights.devigation.member.query.application.service.FindMemberService;
+import com.darknights.devigation.security.command.domain.service.RequestMember;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@InfraService
+public class RequestMemberService implements RequestMember {
+
+    private final FindMemberService findMemberService;
+
+    @Autowired
+    public RequestMemberService(FindMemberService findMemberService) {
+        this.findMemberService = findMemberService;
+    }
+
+    @Override
+    public FindMemberDTO getMemberById(long memberId) {
+        return findMemberService.findById(memberId);
+    }
+}

--- a/src/test/java/com/darknights/devigation/common/advice/AuthControllerAdviceTest.java
+++ b/src/test/java/com/darknights/devigation/common/advice/AuthControllerAdviceTest.java
@@ -1,0 +1,36 @@
+package com.darknights.devigation.common.advice;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.darknights.devigation.common.entity.error.ErrorResponse;
+import com.darknights.devigation.security.command.application.service.CustomTokenService;
+import com.darknights.devigation.security.command.domain.exception.OAuth2AuthenticationProcessingException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@SpringBootTest
+@Transactional
+class AuthControllerAdviceTest {
+
+    @Autowired
+    private AuthControllerAdvice authControllerAdvice;
+
+    @Autowired
+    private CustomTokenService customTokenService;
+
+    @DisplayName("토큰이 없을 경우 정상적으로 401 상태 코드를 응답하는지 테스트")
+    @Test
+    public void testHandleAuthenticationExceptionReturn401() {
+
+        String token = "";
+
+        OAuth2AuthenticationProcessingException exception = assertThrows(OAuth2AuthenticationProcessingException.class, () -> customTokenService.validateToken(token));
+        ResponseEntity<ErrorResponse> responseEntity = authControllerAdvice.handleAuthenticationException(exception);
+        assertEquals(401, responseEntity.getStatusCodeValue());
+    }
+}

--- a/src/test/java/com/darknights/devigation/common/advice/AuthControllerAdviceTest.java
+++ b/src/test/java/com/darknights/devigation/common/advice/AuthControllerAdviceTest.java
@@ -3,7 +3,7 @@ package com.darknights.devigation.common.advice;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.darknights.devigation.common.entity.error.ErrorResponse;
-import com.darknights.devigation.security.command.application.service.CustomTokenService;
+import com.darknights.devigation.security.command.domain.service.CustomTokenService;
 import com.darknights.devigation.security.command.domain.exception.OAuth2AuthenticationProcessingException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/darknights/devigation/common/filter/TokenAuthenticationFilterTest.java
+++ b/src/test/java/com/darknights/devigation/common/filter/TokenAuthenticationFilterTest.java
@@ -39,6 +39,14 @@ class TokenAuthenticationFilterTest {
     private CustomTokenService customTokenService;
 
     @Autowired
+    private CustomUserDetailService customUserDetailService;
+
+
+
+    TokenAuthenticationFilter tokenAuthenticationFilter(CustomTokenService customTokenService, CustomUserDetailService customUserDetailService) {
+        return new TokenAuthenticationFilter(customTokenService, customUserDetailService);
+    }
+
     private TokenAuthenticationFilter tokenAuthenticationFilter;
 
     private MockHttpServletRequest mockRequest;
@@ -48,16 +56,18 @@ class TokenAuthenticationFilterTest {
     private TokenAuthenticationFilter mockTokenAuthenticationFilter;
     private UserPrincipal userPrincipal;
     private CustomUserDetailService mockUserDetailsService;
-    private CustomTokenService mockCustomTokenService;
     private Member member;
 
     @BeforeEach
     void setUp() {
+        tokenAuthenticationFilter = tokenAuthenticationFilter(customTokenService, customUserDetailService);
+
+
         mockRequest = new MockHttpServletRequest();
         mockResponse = new MockHttpServletResponse();
         mockFilterChain = new MockFilterChain();
         mockUserDetailsService = mock(CustomUserDetailService.class);
-        mockCustomTokenService = mock(CustomTokenService.class);
+        CustomTokenService mockCustomTokenService = mock(CustomTokenService.class);
 
         member = createMemberService.create(new CreateMemberDTO(
                 "UIDTEST",

--- a/src/test/java/com/darknights/devigation/common/filter/TokenAuthenticationFilterTest.java
+++ b/src/test/java/com/darknights/devigation/common/filter/TokenAuthenticationFilterTest.java
@@ -5,7 +5,7 @@ import com.darknights.devigation.member.command.application.service.CreateMember
 import com.darknights.devigation.member.command.domain.aggregate.entity.Member;
 import com.darknights.devigation.member.command.domain.aggregate.entity.enumType.PlatformEnum;
 import com.darknights.devigation.member.command.domain.aggregate.entity.enumType.Role;
-import com.darknights.devigation.security.command.application.service.CustomTokenService;
+import com.darknights.devigation.security.command.domain.service.CustomTokenService;
 import com.darknights.devigation.security.command.application.service.CustomUserDetailService;
 import com.darknights.devigation.security.token.UserPrincipal;
 import org.junit.jupiter.api.Assertions;

--- a/src/test/java/com/darknights/devigation/security/command/application/service/CustomTokenServiceTest.java
+++ b/src/test/java/com/darknights/devigation/security/command/application/service/CustomTokenServiceTest.java
@@ -1,7 +1,6 @@
 package com.darknights.devigation.security.command.application.service;
-import com.darknights.devigation.member.command.application.dto.CreateMemberDTO;
-import com.darknights.devigation.member.command.domain.aggregate.entity.enumType.PlatformEnum;
 import com.darknights.devigation.member.command.domain.aggregate.entity.enumType.Role;
+import com.darknights.devigation.security.command.domain.service.CustomTokenService;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import org.junit.jupiter.api.Assertions;

--- a/src/test/java/com/darknights/devigation/security/command/application/service/IssueTokenServiceTest.java
+++ b/src/test/java/com/darknights/devigation/security/command/application/service/IssueTokenServiceTest.java
@@ -1,0 +1,59 @@
+package com.darknights.devigation.security.command.application.service;
+
+import com.darknights.devigation.member.command.domain.aggregate.entity.enumType.Role;
+
+import com.darknights.devigation.security.command.domain.service.CustomTokenService;
+import com.darknights.devigation.security.token.UserPrincipal;
+import org.junit.jupiter.api.*;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import org.springframework.security.test.context.support.WithAnonymousUser;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+class IssueTokenServiceTest {
+
+    static CustomTokenService customTokenService;
+    static IssueTokenService issueTokenService;
+    static UserPrincipal userPrincipal;
+    static String defaultAccessToken;
+    @BeforeAll
+    static void beforeAll(){
+
+        customTokenService = Mockito.mock(CustomTokenService.class);
+        issueTokenService = Mockito.mock(IssueTokenService.class);
+
+        userPrincipal = UserPrincipal.builder(1L, "test", Role.MEMBER.name()).build();
+        defaultAccessToken = customTokenService.createToken(userPrincipal.getId(), userPrincipal.getRole());
+    }
+
+
+    @DisplayName("UserPrincipal을 통해 정상적으로 토큰 발행이 되는지 테스트")
+    @Test
+    @WithAnonymousUser
+    void testIssueTokenByUserPrincipal() {
+
+        when(issueTokenService.issueTokenByUserPrincipal(userPrincipal)).thenReturn(anyString());
+
+        Assertions.assertNotNull(issueTokenService.issueTokenByUserPrincipal(userPrincipal));
+    }
+
+    @DisplayName("잘못된 토큰 값 입력 시 IllegalArgumentException이 발생 하는지 테스트")
+    @Test
+    void testIllegalArgumentExceptionInIssueTokenByAccessToken() {
+        when(issueTokenService.issueTokenByAccessToken(""))
+                .thenThrow(new IllegalArgumentException());
+        assertThrows(IllegalArgumentException.class, () -> issueTokenService.issueTokenByAccessToken(""));
+    }
+
+    @DisplayName("Access Token을 통해 정상적으로 토큰 발행이 되는지 테스트")
+    @Test
+    void testIssueTokenByAccessToken() {
+        when(issueTokenService.issueTokenByAccessToken(defaultAccessToken)).thenReturn(anyString());
+        Assertions.assertNotNull(issueTokenService.issueTokenByAccessToken(defaultAccessToken));
+    }
+}

--- a/src/test/java/com/darknights/devigation/security/command/domain/service/CustomTokenServiceTest.java
+++ b/src/test/java/com/darknights/devigation/security/command/domain/service/CustomTokenServiceTest.java
@@ -1,0 +1,27 @@
+package com.darknights.devigation.security.command.domain.service;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class CustomTokenServiceTest {
+
+
+    @Value("${app.auth.testExampleToken}")
+    private String TEST_EXAMPLE_TOKEN;
+
+    @Autowired
+    private CustomTokenService customTokenService;
+
+    @Test
+    void testGetUserIdFromToken() {
+        Long memberId = customTokenService.getUserIdFromToken(TEST_EXAMPLE_TOKEN);
+        Assertions.assertNotNull(memberId);
+
+    }
+}

--- a/src/test/java/com/darknights/devigation/security/command/domain/service/CustomTokenServiceTest.java
+++ b/src/test/java/com/darknights/devigation/security/command/domain/service/CustomTokenServiceTest.java
@@ -1,27 +1,39 @@
 package com.darknights.devigation.security.command.domain.service;
 
+import com.darknights.devigation.member.command.domain.aggregate.entity.enumType.Role;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.stream.Stream;
 
 @SpringBootTest
 @Transactional
 class CustomTokenServiceTest {
 
-
-    @Value("${app.auth.testExampleToken}")
-    private String TEST_EXAMPLE_TOKEN;
-
     @Autowired
     private CustomTokenService customTokenService;
 
-    @Test
-    void testGetUserIdFromToken() {
-        Long memberId = customTokenService.getUserIdFromToken(TEST_EXAMPLE_TOKEN);
-        Assertions.assertNotNull(memberId);
+    private static Stream<Arguments> getTokenInfo() {
+        return Stream.of(
+                Arguments.of(
+                        1L, Role.MEMBER.name()
+                )
+        );
+    }
+
+    @DisplayName("JWT 토큰을 통해 맴버의 id를 정상적으로 출력되는지 테스트")
+    @ParameterizedTest
+    @MethodSource("getTokenInfo")
+    void testGetMemberIdFromToken(long memberId, String memberRole) {
+        String tokenValue = customTokenService.createToken(memberId, memberRole);
+        Long getMemberIdFromToken = customTokenService.getUserIdFromToken(tokenValue);
+        Assertions.assertEquals(memberId, getMemberIdFromToken);
 
     }
 }


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #49 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 모든 API에 대해 JWT 토큰 유효성 검증하던 문제를 해결하였습니다.
* Member 엔티티에서 불필요한 access token 필드를 삭제하였습니다.
* ant pattern 을 이용한 ignore 처리를 수정하였습니다.
```
You are asking Spring Security to ignore Ant [...]. This is not recommended -- please use permitAll via HttpSecurity#authorizeHttpRequests instead.
```
이 로그는 Spring Security 5.5.x 에 추가되었으며 [Spring Security GitHub Issue](https://github.com/spring-projects/spring-security/issues/10938) 에서 그 이유에 대해 답변을 확인할 수 있습니다.

> web.ignoring() 은 Spring Security 가 해당 엔드포인트에 보안 헤더 또는 기타 보호 조치를 제공할 수
> 없음을 의미한다. 따라서 authorizeHttpRequests permitAll 을 사용 할 경우 권한은 검증하지 않으면서
> 요청을 보호 할수 있으므로 권장된다.
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* access token을 재발급하는 API를 생성하였습니다.
    - 발급한 access token을 저장하는 TOKEN 테이블을 생성하였습니다.
    - 첫 로그인 시 맴버 아이디와 발급받은 access token을 저장합니다.
---

# 관련 스크린샷

<img width="1383" alt="CleanShot 2023-08-19 at 22 01 10@2x" src="https://github.com/The-Dark-Nights/back-end/assets/19159759/25452ce0-81b3-4648-bb4d-cc0ec6465057">

---
* 없음
---

# 테스트 계획 또는 완료 사항

<img width="1190" alt="CleanShot 2023-08-19 at 21 19 41@2x" src="https://github.com/The-Dark-Nights/back-end/assets/19159759/d6d7bdc2-f7c0-4159-9101-5569dfcf3a5a">

---
* UserPrincipal을 통해 정상적으로 토큰 발행이 되는지 테스트를 완료하였습니다.
* 잘못된 토큰 값 입력 시 IllegalArgumentException이 발생 하는지 테스트를 완료하였습니다.
* Access Token을 통해 정상적으로 토큰 발행이 되는지 테스트를 완료하였습니다.

