### PR TITLE
[Closes #68, Closes #69] Test : AuthControllerAdvice에 대한 통합 테스트 진행

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -28,6 +28,11 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
 
+      - name: Set Timezone
+        uses: szenius/set-timezone@v1.2
+        with:
+          timezoneLinux: "Asia/Seoul"
+
       - name: Setup MySQL
         uses: samin/mysql-action@v1
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.3.1'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+    implementation 'org.apache.httpcomponents:httpclient:4.5.13'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2'
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/darknights/devigation/common/advice/AuthControllerAdvice.java
+++ b/src/main/java/com/darknights/devigation/common/advice/AuthControllerAdvice.java
@@ -4,6 +4,7 @@ package com.darknights.devigation.common.advice;
 import com.darknights.devigation.common.entity.api.ApiResponse;
 import com.darknights.devigation.common.entity.error.ErrorResponseBody;
 import com.darknights.devigation.common.entity.error.ErrorResponse;
+import com.darknights.devigation.common.exception.BadRequestException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
@@ -15,8 +16,6 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @RestControllerAdvice
 public class AuthControllerAdvice {
@@ -39,6 +38,26 @@ public class AuthControllerAdvice {
                 .setApiResponse(apiResponse)
                 .setResult(errorResponseBody);
         return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED).body(errorResponse);
+    }
+
+    @ExceptionHandler(BadRequestException.class)
+    protected ResponseEntity<ErrorResponse> handleBadRequestException(
+            MissingRequestHeaderException ex) {
+
+        ErrorResponseBody errorResponseBody = new ErrorResponseBody()
+                .setCode(HttpStatus.BAD_REQUEST.getReasonPhrase())
+                .setClasses(ex.getClass().getSimpleName());
+
+        ApiResponse apiResponse = new ApiResponse()
+                .setStatus(HttpStatus.BAD_REQUEST.value())
+                .setMessage(ex.getLocalizedMessage())
+                .setTimestamp(LocalDateTime.now());
+
+
+        ErrorResponse errorResponse = new ErrorResponse()
+                .setApiResponse(apiResponse)
+                .setResult(errorResponseBody);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
     }
 
     @ExceptionHandler(MissingRequestHeaderException.class)

--- a/src/main/java/com/darknights/devigation/common/entity/api/ApiResponse.java
+++ b/src/main/java/com/darknights/devigation/common/entity/api/ApiResponse.java
@@ -1,6 +1,9 @@
 package com.darknights.devigation.common.entity.api;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -12,7 +15,8 @@ public class ApiResponse {
     public int status;
     public String message;
 
-    @JsonFormat(pattern="yyyy-MM-dd HH:mm:ss", timezone="Asia/Seoul")
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
     public LocalDateTime timestamp = LocalDateTime.now();
 
     public ApiResponse() {}

--- a/src/main/java/com/darknights/devigation/common/entity/api/ApiResponse.java
+++ b/src/main/java/com/darknights/devigation/common/entity/api/ApiResponse.java
@@ -1,5 +1,6 @@
 package com.darknights.devigation.common.entity.api;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
@@ -15,8 +16,6 @@ public class ApiResponse {
     public int status;
     public String message;
 
-    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
-    @JsonSerialize(using = LocalDateTimeSerializer.class)
     public LocalDateTime timestamp = LocalDateTime.now();
 
     public ApiResponse() {}

--- a/src/main/java/com/darknights/devigation/common/filter/AuthenticationExceptionFilter.java
+++ b/src/main/java/com/darknights/devigation/common/filter/AuthenticationExceptionFilter.java
@@ -1,6 +1,5 @@
 package com.darknights.devigation.common.filter;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -16,7 +15,6 @@ public class AuthenticationExceptionFilter extends OncePerRequestFilter {
 
     private final HandlerExceptionResolver resolver;
 
-    @Autowired
     public AuthenticationExceptionFilter(@Qualifier("handlerExceptionResolver")  HandlerExceptionResolver resolver) {
         this.resolver = resolver;
     }
@@ -31,7 +29,7 @@ public class AuthenticationExceptionFilter extends OncePerRequestFilter {
         }
     }
 
-    private void setErrorResponse(HttpServletRequest request, HttpServletResponse response, AuthenticationException ex) throws IOException {
+    private void setErrorResponse(HttpServletRequest request, HttpServletResponse response, AuthenticationException ex) {
 
 //        String requestUrl = null;
 //        if(ex.getClass() == UserNotFoundException.class) {

--- a/src/main/java/com/darknights/devigation/configuration/JacksonConfiguration.java
+++ b/src/main/java/com/darknights/devigation/configuration/JacksonConfiguration.java
@@ -1,0 +1,33 @@
+package com.darknights.devigation.configuration;
+
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.format.DateTimeFormatter;
+
+@Configuration
+public class JacksonConfiguration {
+    @Bean
+    public Jackson2ObjectMapperBuilderCustomizer jackson2ObjectMapperBuilderCustomizer() {
+
+        return builder -> {
+
+            // formatter
+            DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+            DateTimeFormatter dateTimeFormatter =  DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+            // deserializers
+            builder.deserializers(new LocalDateDeserializer(dateFormatter));
+            builder.deserializers(new LocalDateTimeDeserializer(dateTimeFormatter));
+
+            // serializers
+            builder.serializers(new LocalDateSerializer(dateFormatter));
+            builder.serializers(new LocalDateTimeSerializer(dateTimeFormatter));
+        };
+    }
+}

--- a/src/main/java/com/darknights/devigation/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/darknights/devigation/configuration/SecurityConfiguration.java
@@ -24,9 +24,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 
 @RequiredArgsConstructor
@@ -41,15 +38,19 @@ public class SecurityConfiguration {
 
     @Autowired
     @Qualifier("RestAuthenticationEntryPoint")
-    AuthenticationEntryPoint authEntryPoint;
+    private AuthenticationEntryPoint authEntryPoint;
+
     @Autowired
     private CustomTokenService customTokenService;
     @Autowired
     private CustomUserDetailService customUserDetailService;
+    @Autowired
+    @Qualifier("handlerExceptionResolver")
     private HandlerExceptionResolver resolver;
 
 
-    AuthenticationExceptionFilter authenticationExceptionFilter(@Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver) {
+
+    AuthenticationExceptionFilter authenticationExceptionFilter(HandlerExceptionResolver resolver) {
         return new AuthenticationExceptionFilter(resolver);
     }
 
@@ -151,7 +152,7 @@ public class SecurityConfiguration {
                     .antMatchers("/blog/**", "/member/**")
                         .permitAll()
                     .antMatchers("/admin/**")
-                        .hasRole(Role.BAN.name())
+                        .hasRole(Role.ADMIN.name())
                     .and()
                 .oauth2Login()
                     .authorizationEndpoint()

--- a/src/main/java/com/darknights/devigation/member/command/domain/repository/MemberRepository.java
+++ b/src/main/java/com/darknights/devigation/member/command/domain/repository/MemberRepository.java
@@ -2,6 +2,8 @@ package com.darknights.devigation.member.command.domain.repository;
 
 import com.darknights.devigation.member.command.domain.aggregate.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 }

--- a/src/main/java/com/darknights/devigation/member/query/domain/aggregate/entity/enumType/Role.java
+++ b/src/main/java/com/darknights/devigation/member/query/domain/aggregate/entity/enumType/Role.java
@@ -9,7 +9,8 @@ public enum Role {
 
     GUEST("ROLE_GUEST", "손님"),
     MEMBER("ROLE_MEMBER", "일반 사용자"),
-    BAN("ROLE_BAN", "차단 사용자");
+    BAN("ROLE_BAN", "차단 사용자"),
+    ADMIN("ROLE_ADMIN", "관리자");
 
     private final String key;
     private final String title;

--- a/src/test/java/com/darknights/devigation/common/advice/AuthControllerAdviceIntegrationTest.java
+++ b/src/test/java/com/darknights/devigation/common/advice/AuthControllerAdviceIntegrationTest.java
@@ -1,0 +1,152 @@
+package com.darknights.devigation.common.advice;
+
+import com.darknights.devigation.common.entity.error.ErrorResponse;
+import com.darknights.devigation.member.command.application.dto.CreateMemberDTO;
+import com.darknights.devigation.member.command.application.service.CreateMemberService;
+import com.darknights.devigation.member.command.domain.aggregate.entity.Member;
+import com.darknights.devigation.member.command.domain.aggregate.entity.enumType.PlatformEnum;
+import com.darknights.devigation.member.command.domain.aggregate.entity.enumType.Role;
+import com.darknights.devigation.security.command.domain.exception.OAuth2AuthenticationProcessingException;
+import com.darknights.devigation.security.command.domain.exception.UserNotFoundException;
+import com.darknights.devigation.security.command.domain.service.CustomTokenService;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.*;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+import java.nio.file.AccessDeniedException;
+import java.util.stream.Stream;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class AuthControllerAdviceIntegrationTest {
+
+    /*
+     * TestRestTemplate은 REST 방식으로 개발한 API의 Test를 최적화 하기 위해 만들어진 클래스이다.
+     * HTTP 요청 후 데이터를 응답 받을 수 있는 템플릿 객체이며 ResponseEntity와 함께 자주 사용된다.
+     * Header와 Content-Type 등을 설정하여 API를 호출 할 수 있다.
+     * */
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private CustomTokenService customTokenService;
+
+    @Autowired
+    private CreateMemberService createMemberService;
+
+    @DisplayName("존재하지 않는 url 요청시 NOT_FOUND ErrorResponse를 응답하는지 테스트")
+    @Test
+    void testThrowNullPointerException() {
+        ResponseEntity<ErrorResponse> errorResponse = restTemplate.getForEntity("/auth", ErrorResponse.class);
+        Assertions.assertThat(errorResponse.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        Assertions.assertThat(errorResponse.getBody().getResult().getClasses()).isEqualTo(NoHandlerFoundException.class.getSimpleName());
+    }
+
+    @DisplayName("유효하지 않는 Http 메소드 요청시 METHOD_NOT_ALLOWED ErrorResponse를 응답하는지 테스트")
+    @Test
+    void testHttpRequestMethodNotSupportedException() {
+        ResponseEntity<ErrorResponse> errorResponse = restTemplate.getForEntity("/auth/token", ErrorResponse.class);
+        Assertions.assertThat(errorResponse.getStatusCode()).isEqualTo(HttpStatus.METHOD_NOT_ALLOWED);
+        Assertions.assertThat(errorResponse.getBody().getResult().getClasses()).isEqualTo(HttpRequestMethodNotSupportedException.class.getSimpleName());
+    }
+
+    @DisplayName("Security를 통하지 않고 헤더에 필요한 값이 없을 경우 BAD_REQUEST ErrorResponse를 응답하는지 테스트")
+    @Test
+    void testMissingRequestHeaderException() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<String> request =
+                new HttpEntity<>("", headers);
+        ResponseEntity<ErrorResponse> errorResponse = restTemplate.postForEntity("/auth/token",request, ErrorResponse.class);
+        Assertions.assertThat(errorResponse.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        Assertions.assertThat(errorResponse.getBody().getResult().getClasses()).isEqualTo(MissingRequestHeaderException.class.getSimpleName());
+    }
+
+    @DisplayName("Authorization에 JWT 토큰이 없을 경우 UNAUTHORIZED ErrorResponse를 응답하는지 테스트")
+    @Test
+    void testNullTokenAuthenticationException() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<String> request =
+                new HttpEntity<>(headers);
+
+        ResponseEntity<ErrorResponse> errorResponse = restTemplate.exchange("/admin/", HttpMethod.GET,request,ErrorResponse.class);
+        Assertions.assertThat(errorResponse.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        Assertions.assertThat(errorResponse.getBody().getResult().getClasses()).isEqualTo(OAuth2AuthenticationProcessingException.class.getSimpleName());
+        Assertions.assertThat(errorResponse.getBody().getApiResponse().getMessage()).isEqualTo("JWT 토큰이 존재하지 않습니다.");
+    }
+
+    @DisplayName("Authorization에 잘못된 형식의 JWT 토큰이 입력 시 UNAUTHORIZED ErrorResponse를 응답하는지 테스트")
+    @Test
+    void testUnValidAuthenticationException() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.add("Authorization", "Bearer test");
+        HttpEntity<String> request =
+                new HttpEntity<>(headers);
+
+        ResponseEntity<ErrorResponse> errorResponse = restTemplate.exchange("/admin/", HttpMethod.GET,request,ErrorResponse.class);
+        Assertions.assertThat(errorResponse.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        Assertions.assertThat(errorResponse.getBody().getResult().getClasses()).isEqualTo(OAuth2AuthenticationProcessingException.class.getSimpleName());
+        Assertions.assertThat(errorResponse.getBody().getApiResponse().getMessage()).isEqualTo("잘못된 JWT 서명");
+    }
+
+    @DisplayName("존재하지 않는 사용자 Id의 토큰으로 요청 시 UNAUTHORIZED ErrorResponse를 응답하는지 테스트")
+    @Test
+    void testUserNotFoundException() {
+        String testToken = customTokenService.createToken(0L, "MEMBER");
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.add("Authorization", "Bearer " + testToken);
+        HttpEntity<String> request =
+                new HttpEntity<>(headers);
+
+        ResponseEntity<ErrorResponse> errorResponse = restTemplate.exchange("/admin", HttpMethod.GET,request,ErrorResponse.class);
+        Assertions.assertThat(errorResponse.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        Assertions.assertThat(errorResponse.getBody().getResult().getClasses()).isEqualTo(UserNotFoundException.class.getSimpleName());
+        Assertions.assertThat(errorResponse.getBody().getApiResponse().getMessage()).isEqualTo("해당 Id를 가진 사용자를 찾을 수 없습니다.");
+    }
+
+    private static Stream<Arguments> getMemberInfo() {
+        return Stream.of(
+                Arguments.of(
+                        new CreateMemberDTO(
+                                "1122ss",
+                                "testMember",
+                                Role.MEMBER,
+                                "email@test.com",
+                                "profileImage",
+                                PlatformEnum.GITHUB
+                        )
+                )
+        );
+    }
+    @DisplayName("권한이 없는 사용자가 API 요청 시 Forbidden ErrorResponse를 응답하는지 테스트")
+    @ParameterizedTest
+    @MethodSource("getMemberInfo")
+    void testAccessDeniedExceptionException(CreateMemberDTO createMemberDTO) {
+        Member member = createMemberService.create(createMemberDTO);
+        String testToken = customTokenService.createToken(member.getId(), member.getRole().name());
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.add("Authorization", "Bearer " + testToken);
+        HttpEntity<String> request =
+                new HttpEntity<>(headers);
+
+        ResponseEntity<ErrorResponse> errorResponse = restTemplate.exchange("/admin/", HttpMethod.GET,request,ErrorResponse.class);
+        Assertions.assertThat(errorResponse.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+        Assertions.assertThat(errorResponse.getBody().getResult().getClasses()).isEqualTo(AccessDeniedException.class.getSimpleName());
+        Assertions.assertThat(errorResponse.getBody().getApiResponse().getMessage()).isEqualTo("API에 접근할 권한이 없습니다.");
+    }
+}

--- a/src/test/java/com/darknights/devigation/common/advice/AuthControllerAdviceIntegrationTest.java
+++ b/src/test/java/com/darknights/devigation/common/advice/AuthControllerAdviceIntegrationTest.java
@@ -51,7 +51,12 @@ public class AuthControllerAdviceIntegrationTest {
     @DisplayName("존재하지 않는 url 요청시 NOT_FOUND ErrorResponse를 응답하는지 테스트")
     @Test
     void testThrowNullPointerException() {
-        ResponseEntity<ErrorResponse> errorResponse = restTemplate.getForEntity("/auth", ErrorResponse.class);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<String> request =
+                new HttpEntity<>(headers);
+        ResponseEntity<ErrorResponse> errorResponse = restTemplate.exchange("/auth",HttpMethod.GET,request, ErrorResponse.class);
+        System.out.println("errorResponse.getBody().getApiResponse().getTimestamp() = " + errorResponse.getBody().getApiResponse().getTimestamp());
         Assertions.assertThat(errorResponse.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
         Assertions.assertThat(errorResponse.getBody().getResult().getClasses()).isEqualTo(NoHandlerFoundException.class.getSimpleName());
     }
@@ -59,7 +64,11 @@ public class AuthControllerAdviceIntegrationTest {
     @DisplayName("유효하지 않는 Http 메소드 요청시 METHOD_NOT_ALLOWED ErrorResponse를 응답하는지 테스트")
     @Test
     void testHttpRequestMethodNotSupportedException() {
-        ResponseEntity<ErrorResponse> errorResponse = restTemplate.getForEntity("/auth/token", ErrorResponse.class);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<String> request =
+                new HttpEntity<>(headers);
+        ResponseEntity<ErrorResponse> errorResponse = restTemplate.exchange("/auth/token",HttpMethod.GET,request, ErrorResponse.class);
         Assertions.assertThat(errorResponse.getStatusCode()).isEqualTo(HttpStatus.METHOD_NOT_ALLOWED);
         Assertions.assertThat(errorResponse.getBody().getResult().getClasses()).isEqualTo(HttpRequestMethodNotSupportedException.class.getSimpleName());
     }

--- a/src/test/java/com/darknights/devigation/common/advice/AuthControllerAdviceIntegrationTest.java
+++ b/src/test/java/com/darknights/devigation/common/advice/AuthControllerAdviceIntegrationTest.java
@@ -6,6 +6,7 @@ import com.darknights.devigation.member.command.application.service.CreateMember
 import com.darknights.devigation.member.command.domain.aggregate.entity.Member;
 import com.darknights.devigation.member.command.domain.aggregate.entity.enumType.PlatformEnum;
 import com.darknights.devigation.member.command.domain.aggregate.entity.enumType.Role;
+import com.darknights.devigation.member.command.domain.repository.MemberRepository;
 import com.darknights.devigation.security.command.domain.exception.OAuth2AuthenticationProcessingException;
 import com.darknights.devigation.security.command.domain.exception.UserNotFoundException;
 import com.darknights.devigation.security.command.domain.service.CustomTokenService;
@@ -43,6 +44,9 @@ public class AuthControllerAdviceIntegrationTest {
 
     @Autowired
     private CreateMemberService createMemberService;
+
+    @Autowired
+    private MemberRepository memberRepository;
 
     @DisplayName("존재하지 않는 url 요청시 NOT_FOUND ErrorResponse를 응답하는지 테스트")
     @Test
@@ -145,6 +149,7 @@ public class AuthControllerAdviceIntegrationTest {
                 new HttpEntity<>(headers);
 
         ResponseEntity<ErrorResponse> errorResponse = restTemplate.exchange("/admin/", HttpMethod.GET,request,ErrorResponse.class);
+        memberRepository.delete(member);
         Assertions.assertThat(errorResponse.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
         Assertions.assertThat(errorResponse.getBody().getResult().getClasses()).isEqualTo(AccessDeniedException.class.getSimpleName());
         Assertions.assertThat(errorResponse.getBody().getApiResponse().getMessage()).isEqualTo("API에 접근할 권한이 없습니다.");

--- a/src/test/java/com/darknights/devigation/common/advice/AuthControllerAdviceUnitTest.java
+++ b/src/test/java/com/darknights/devigation/common/advice/AuthControllerAdviceUnitTest.java
@@ -10,12 +10,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.ResponseEntity;
-import org.springframework.transaction.annotation.Transactional;
 
 
-@SpringBootTest
-@Transactional
-class AuthControllerAdviceTest {
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class AuthControllerAdviceUnitTest {
 
     @Autowired
     private AuthControllerAdvice authControllerAdvice;

--- a/src/test/java/com/darknights/devigation/common/advice/SecurityAdviceIntegrationTest.java
+++ b/src/test/java/com/darknights/devigation/common/advice/SecurityAdviceIntegrationTest.java
@@ -1,0 +1,107 @@
+package com.darknights.devigation.common.advice;
+
+
+
+import com.darknights.devigation.common.filter.TokenAuthenticationFilter;
+import com.darknights.devigation.member.command.domain.aggregate.entity.enumType.PlatformEnum;
+import com.darknights.devigation.member.command.domain.aggregate.entity.enumType.Role;
+import com.darknights.devigation.member.query.application.dto.FindMemberDTO;
+import com.darknights.devigation.member.query.application.service.FindMemberService;
+import com.darknights.devigation.security.command.application.service.CustomUserDetailService;
+import com.darknights.devigation.security.command.domain.service.CustomTokenService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.stream.Stream;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class SecurityAdviceIntegrationTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    private CustomTokenService customTokenService;
+
+    @Autowired
+    private CustomUserDetailService customUserDetailService;
+
+    @MockBean
+    private FindMemberService findMemberService;
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @BeforeEach
+    public void setup(){
+
+        // mvc
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply(springSecurity())
+                .addFilter(new TokenAuthenticationFilter(customTokenService, customUserDetailService))
+                .build();
+
+    }
+
+    private static Stream<Arguments> getMemberInfo() {
+        return Stream.of(
+                Arguments.of(
+                        new FindMemberDTO(
+                                0L,
+                                "mockName",
+                                "email@test.com",
+                                "profileImage",
+                                PlatformEnum.GITHUB.name(),
+                                Role.MEMBER.name()
+                        )
+                )
+        );
+    }
+
+    @DisplayName("권한이 없는 사용자가 API 요청 시 Forbidden ErrorResponse를 응답하는지 테스트")
+    @ParameterizedTest
+    @MethodSource("getMemberInfo")
+    void testAccessDeniedExceptionException(FindMemberDTO findMemberDTO) throws Exception {
+
+        when(findMemberService.findById(0L)).thenReturn(findMemberDTO);
+
+        String testToken = customTokenService.createToken(findMemberDTO.getId(), findMemberDTO.getRole());
+        mockMvc.perform(
+                get("/admin")
+                        .header("Authorization", "Bearer " + testToken)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                )
+                .andDo(print())
+                .andExpectAll(
+                       jsonPath("$.status").value(equalTo(403)),
+                        jsonPath("$.result.code").value(equalTo("Forbidden")),
+                        jsonPath("$.result.classes").value(equalTo("AccessDeniedException"))
+                );
+    }
+}

--- a/src/test/java/com/darknights/devigation/common/filter/NullPointExceptionFilterTest.java
+++ b/src/test/java/com/darknights/devigation/common/filter/NullPointExceptionFilterTest.java
@@ -1,0 +1,42 @@
+package com.darknights.devigation.common.filter;
+
+import io.jsonwebtoken.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import javax.servlet.ServletException;
+
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+
+@SpringBootTest
+class NullPointExceptionFilterTest {
+
+    private MockHttpServletRequest mockRequest;
+    private MockHttpServletResponse mockResponse;
+    private MockFilterChain mockFilterChain;
+    @Autowired
+    private NullPointExceptionFilter nullPointExceptionFilter;
+
+    @BeforeEach
+    void setUp() {
+        mockRequest = new MockHttpServletRequest();
+        mockResponse = new MockHttpServletResponse();
+        mockFilterChain = new MockFilterChain();
+
+    }
+
+    @DisplayName("nullPointExceptionFilter 에서 다음 필터로 넘어 가는지 테스트")
+    @Test
+    void testFilterContinuesTONextFilter() throws ServletException, IOException, java.io.IOException {
+        MockFilterChain mockFilterChainSpy = spy(mockFilterChain);
+        nullPointExceptionFilter.doFilterInternal(mockRequest, mockResponse, mockFilterChainSpy);
+        verify(mockFilterChainSpy, times(1)).doFilter(mockRequest, mockResponse);
+    }
+}


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #68 
* #69 
---
# 어떤 위험이나 장애가 발견되었는지

---
* `SecurityConfiguration` 에서 `HandlerExceptionResolver` 클래스의 의존성 주입을 못받는 문제를 해결하였습니다.
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* 예외 처리에 대한 통합 클래스인 `AuthControllerAdvice` 클래스에 대해 통합 테스트를 진행하였습니다.
* 예외 처리에 대한 통합 클래스인 `AuthControllerAdvice` 클래스에 대해 단위 테스트를 진행하였습니다.
* `NullPointExceptionFilterTest` 클래스에 대해 단위 테스트를 진행하였습니다.

* 응답 객체인 `ResponseEntity`를 통한 Rest API 방식으로 개발한 API의 Test를 최적화 하기 위해 만들어진 `TestRestTemplate` 를 통해 통합 테스트를 진행하였습니다. 
    > 해당 클래스에 대해선 Wiki 탭에 정리할 예정입니다.

* `TestRestTemplate` 를 사용할 경우 `@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)` 어노테이션을 사용해야 할 때 `@Transactional` 어노테이션이 작동하지 않던 문제를 확인하여 강제로 데이터를 삭제하였습니다.

> @SpringBootTest에서 트랜잭션 롤백되지 않는 이유
> @SpringBootTest를 RANDOM_PORT나 DEFINED_PORT로 사용하면 별도의 쓰레드에서 스프링 컨테이너가 실행된다.
> 테스트가 끝나고 이를 롤백시키려면 하나의 트랜잭션으로 묶여야 하는데, 스프링 컨테이너가 실제로 구동되어 테스트와 다른 쓰레드에서 실행되니 > 하나의 트랜잭션으로 묶일 수 없는 것이다. 
> 그래서 @SpringBootTest를 RANDOM_PORT나 DEFINED_PORT로 사용하면 @Transactional을 사용해도 롤백되지 않는다. 

- 참고 자료 : https://mangkyu.tistory.com/264

* 위 이슈로 인해 토큰을 통해 사용자 정보를 검증하는 로직의 경우 Mockito 라이브러리를 이용하여 테스트하는 방식으로 구현하였습니다.    
헤더에 인증 토큰을 추가하여 API를 요청하면 Security는 토큰을 검증한 후, 토큰 내부에 있는 사용자 Id를 통해 해당 Id를 가진 사용자가 데이터베이스에 있는지 조회합니다. 하지만 테스트 환경에서는 해당 과정을 처리할 수 없기 때문에 저희는 MockBean을 통해 테스트를 진행하였습니다.

``` java
public class TokenAuthenticationFilter extends OncePerRequestFilter {
    ...

@Override
    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
        String jwt = getJwtFromRequest(request);
        if (StringUtils.hasText(jwt) && customTokenService.validateToken(jwt)) {
            Long userId = customTokenService.getUserIdFromToken(jwt);
            UserDetails userDetails = customUserDetailService.loadUserById(userId);
            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));

            SecurityContextHolder.getContext().setAuthentication(authentication);
        }

        filterChain.doFilter(request, response);
    }
...
}
```
위 코드처럼 API 요청이 들어오면 `TokenAuthenticationFilter`에서 토큰의 유효성 검증과 사용자 존재 여부를 체크한 후 다음 filterChain으로 넘어갑니다. 따라서 테스트 환경에서 해당 필터를 문제없이 하기 위해서는 `customUserDetailService.loadUserById(userId)` 코드를 Mock으로 구성한 후 ` when(findMemberService.findById(0L)).thenReturn(mockFindMemberDTO);` 의 `when().thenReturn()` 문을 통해 `when` 내부에 정의한 mock 객체의 메소드가 호출될 때 사전에 정의한`mockFindMemberDTO` 를 반환하도록 구현하였습니다.

---

# 관련 스크린샷
---

# 추가 사항
---
* 추후 Wiki 탭에 테스트에 대한 내용을 새로 작성할 예정입니다.
* 추후 Wiki 탭에 예외 처리에 대한 내용을 업데이트할 예정입니다.
---

# 테스트 계획 또는 완료 사항

![CleanShot 2023-08-24 at 00 09 32](https://github.com/The-Dark-Nights/back-end/assets/19159759/a1ea9219-942c-469e-ab87-ede5fea9029e)

<img width="1238" alt="CleanShot 2023-08-24 at 20 00 38@2x" src="https://github.com/The-Dark-Nights/back-end/assets/19159759/bad6da27-e300-44a4-a4f4-8734627e233d">


---
* 테스트 관련 사항을 입력한다.
