### PR TITLE
[#51] 사진 데이터 AWS S3처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,10 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.3.1'
     testImplementation 'org.springframework.security:spring-security-test'
+
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    testImplementation 'io.findify:s3mock_2.13:0.2.6'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/darknights/devigation/DevigationApplication.java
+++ b/src/main/java/com/darknights/devigation/DevigationApplication.java
@@ -10,7 +10,13 @@ import javax.annotation.PostConstruct;
 import java.util.TimeZone;
 
 @EnableJpaAuditing
-@SpringBootApplication
+@SpringBootApplication(
+        exclude = {
+                org.springframework.cloud.aws.autoconfigure.context.ContextInstanceDataAutoConfiguration.class,
+                org.springframework.cloud.aws.autoconfigure.context.ContextStackAutoConfiguration.class,
+                org.springframework.cloud.aws.autoconfigure.context.ContextRegionProviderAutoConfiguration.class
+        }
+)
 @EnableConfigurationProperties(AppProperties.class)
 public class DevigationApplication {
 
@@ -23,5 +29,4 @@ public class DevigationApplication {
 
         SpringApplication.run(DevigationApplication.class, args);
     }
-
 }

--- a/src/main/java/com/darknights/devigation/aws/command/application/controller/AwsS3Controller.java
+++ b/src/main/java/com/darknights/devigation/aws/command/application/controller/AwsS3Controller.java
@@ -1,0 +1,31 @@
+package com.darknights.devigation.aws.command.application.controller;
+
+import com.darknights.devigation.aws.command.application.service.AwsS3Service;
+import com.darknights.devigation.common.entity.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+public class AwsS3Controller {
+
+    private final AwsS3Service awsS3Service;
+
+    @Autowired
+    public AwsS3Controller(AwsS3Service awsS3Service){
+        this.awsS3Service=awsS3Service;
+    }
+
+    // test용 controller
+    @PostMapping("/image")
+    public String uploadImage(@RequestPart(value="file",required = false) MultipartFile multipartFile){
+        return awsS3Service.uploadImage(multipartFile);
+    }
+
+}

--- a/src/main/java/com/darknights/devigation/aws/command/application/service/AwsS3Service.java
+++ b/src/main/java/com/darknights/devigation/aws/command/application/service/AwsS3Service.java
@@ -1,0 +1,87 @@
+package com.darknights.devigation.aws.command.application.service;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+
+@Service
+public class AwsS3Service {
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Autowired
+    private final AmazonS3Client amazonS3Client ;
+
+    @Autowired
+    public AwsS3Service (AmazonS3Client amazonS3Client){
+        this.amazonS3Client = amazonS3Client;
+    }
+
+
+    public String uploadImage(MultipartFile multipartFiles) {
+
+        String fileName = createFileName(multipartFiles.getOriginalFilename());
+        // UUID 파일명 생성
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        // 객체를 생성해 파일에 대한 메타데이터 설정
+        objectMetadata.setContentLength(multipartFiles.getSize());
+        objectMetadata.setContentType(multipartFiles.getContentType());
+        // Spring Server에서 S3로 파일을 업로드하기 위해
+        // 이때의 파일 사이즈와 파일 타입을 알려주기 위해 ObjectMetadata사용
+
+        String url=null;
+        try (InputStream inputStream = multipartFiles.getInputStream()) {
+            // InputStream을 사용해 파일의 데이터 읽음
+
+            PutObjectRequest uploadFile = new PutObjectRequest(bucket, fileName, inputStream, objectMetadata)
+                    .withCannedAcl(CannedAccessControlList.PublicRead);
+            amazonS3Client.putObject(uploadFile);
+            // 객체를 생성해 S3에 전송, withCannedAcl => 파일을 공개 읽기 권한으로 설정
+
+            url = String.valueOf(amazonS3Client.getUrl(bucket,uploadFile.getKey()));
+
+        } catch (IOException e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+                    "이미지 업로드에 실패했습니다.");
+        }
+        // S3에 저장된 fileNameList(즉, UUID로 변환된 fileNameList)
+
+
+
+        return url;
+    }
+
+    private String createFileName(String fileName) {
+        return UUID.randomUUID().toString().concat(getFileExtension(fileName));
+        // 파일 이름이 증복되지 않게 하기 위해 랜덤으로 UUID 생성
+    }
+
+    private String getFileExtension(String fileName) {
+        try {
+            return fileName.substring(fileName.lastIndexOf("."));
+            // 확장자 ex) asd.png 일 때 확장자 전까지 파일 이름을 반환
+        } catch (StringIndexOutOfBoundsException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "잘못된 형식의 파일(" + fileName + ")입니다.");
+        }
+    }
+
+    public void deleteImage(String fileName) {
+
+        amazonS3Client.deleteObject(new DeleteObjectRequest(bucket, fileName));
+
+    }
+}
+
+
+
+

--- a/src/main/java/com/darknights/devigation/configuration/AwsS3Config.java
+++ b/src/main/java/com/darknights/devigation/configuration/AwsS3Config.java
@@ -1,0 +1,34 @@
+package com.darknights.devigation.configuration;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AwsS3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client(){
+        BasicAWSCredentials awsCreds= new BasicAWSCredentials(accessKey,secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
+                .build();
+    }
+    // AWS S3 client 연결 정보를 Bean으로 생성 후 사용. 버킷 생성 후 key 정보 값을 받아오는 파일.
+
+
+
+}

--- a/src/test/java/com/darknights/devigation/aws/command/application/service/AwsS3ServiceTests.java
+++ b/src/test/java/com/darknights/devigation/aws/command/application/service/AwsS3ServiceTests.java
@@ -1,0 +1,62 @@
+package com.darknights.devigation.aws.command.application.service;
+
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.darknights.devigation.config.AwsS3MockConfig;
+import io.findify.s3mock.S3Mock;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.nio.charset.StandardCharsets;
+
+@Import(AwsS3MockConfig.class)
+// @Configuration 선언된 스프링 설정 클래스 가져오는 것
+@SpringBootTest
+public class AwsS3ServiceTests {
+
+    @Autowired
+    private AwsS3Service awsS3Service;
+
+    @Autowired
+    private S3Mock s3Mock;
+
+    @Autowired
+    private AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+
+    @AfterEach
+    public void tearDown() {
+        s3Mock.stop();
+    }
+
+    @DisplayName("Aws S3 이미지 업로드 테스트")
+    @Test
+    void uploadImageTest() {
+        final String fileName = "testImage"; //파일명
+        final String contentType = "png"; //파일타입
+
+        MockMultipartFile imgFile = new MockMultipartFile(
+                "images",
+                fileName + "." + contentType,
+                contentType,
+                "images".getBytes(StandardCharsets.UTF_8)
+        );
+        String imgUrl = awsS3Service.uploadImage(imgFile);
+        Assertions.assertNotNull(imgUrl);
+
+        String[] imgLocation = imgUrl.split("/");
+
+        // JPA와 다르게 commit rollback 개념이 존재하지 않는 경우
+        // 직접 접근하여 DB(or Cloud)에서 값을 삭제해야한다.
+        // 실제로 앞으로 테스트를 진행하다보면 transactional이 동작하지 않는 경우가 생길텐데 그럴떈 위와 같이 진행해도 된다.
+        awsS3Service.deleteImage(imgLocation[3]);
+        // 수정 이렇게 되면 Mock을 사용한 이유가 크게 존재하지 않을수도 있음
+    }
+}

--- a/src/test/java/com/darknights/devigation/config/AwsS3MockConfig.java
+++ b/src/test/java/com/darknights/devigation/config/AwsS3MockConfig.java
@@ -1,0 +1,47 @@
+package com.darknights.devigation.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.AnonymousAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import io.findify.s3mock.S3Mock;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class AwsS3MockConfig {
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Bean
+    public S3Mock s3Mock(){
+        return new S3Mock.Builder().withPort(9999).withInMemoryBackend().build();
+        // S3Mock 서버로 사용될 S3Mock 등록, 서버 사용 port와 저장유무만 확인하면 되기 때문에 withMemoryBackend() 사용
+    }
+
+    @Bean
+    public AmazonS3 amazonS3(S3Mock s3Mock){
+        s3Mock.start();
+        AwsClientBuilder.EndpointConfiguration endpoint = new AwsClientBuilder
+                .EndpointConfiguration("http://localhost:9999",region);
+
+        AmazonS3 client = AmazonS3ClientBuilder
+                .standard()
+                .withPathStyleAccessEnabled(true)
+                .withEndpointConfiguration(endpoint)
+                .withCredentials(new AWSStaticCredentialsProvider(new AnonymousAWSCredentials()))
+                .build();
+        client.createBucket(bucket);
+        // End point => 서비스에 연결할 떄 필요한 endpoint 정보
+        // AWS 서비스가 호스팅 되는 위치 => http://localhost:9999
+        // endpoint를 명시적으로 지정하지 않을 경우 계정에서 사용하는 지역과 연결된 endpoint를 사용하기 때문에
+        // 테스트할 때는 서버가 호스팅 되는 위치를 명시적으로 지정해준 것
+        return client;
+    }
+}


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* 사진 데이터 AWS S3에 저장 기능 구현
---
# 어떤 위험이나 장애가 발견되었는지

---
* 없음
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* application yml에 추가해야할 사항 => spring/profiles/include에 aws 추가
<img width="59" alt="image" src="https://github.com/The-Dark-Nights/back-end/assets/136034038/314cda91-d6ae-42dc-be8a-297b514d08ef">

* 추가적으로 resources 폴더에 application-aws.yml 파일을 추가해야 합니다. (발급받은 아이디로 인증키,버킷 발급 후 디코에 업로드 예정)

* @TestConfiguration을 사용하여 Test 전용 설정파일을 만들었는데  upload된 사진이 삭제되지 않고 S3에 버킷에 객체로 남아있는 현상이 있었습니다.  
* 직접 접근해서 삭제하는 방법으로 test를 진행했으며 JPA처럼 Transacntional (commit, rollback) 적용되지 않는 경우 직접 삭제해야 하는 경우도 존재한다고하니 참고 바랍니다.

<img width="428" alt="image" src="https://github.com/The-Dark-Nights/back-end/assets/136034038/5b7de7de-9864-4913-91f5-5cfbbf8bf75d">

---

# 관련 스크린샷

---
<img width="940" alt="image" src="https://github.com/The-Dark-Nights/back-end/assets/136034038/eb5f3f81-a052-4067-9fa3-b42ab031ae61">

---

# 테스트 계획 또는 완료 사항

---
<img width="968" alt="image" src="https://github.com/The-Dark-Nights/back-end/assets/136034038/42b05545-9ae0-4c06-9833-a3c0d36cb6f1">.
