### PR TITLE
[Closes #66]Feat : Roadmap Category update 기능 작성,Test : Roadmap Category delete, update 기능 test 작성

### DIFF
--- a/src/main/java/com/darknights/devigation/roadmap/command/application/service/DeleteRoadmapCategoryService.java
+++ b/src/main/java/com/darknights/devigation/roadmap/command/application/service/DeleteRoadmapCategoryService.java
@@ -18,8 +18,13 @@ public class DeleteRoadmapCategoryService {
     }
 
     @Transactional
-    public void deleteRoadmapCategory(long roadmapId){
-        roadmapEdgeRepository.deleteRoadmapEdgesByRoadmapId_Id(roadmapId);
-        roadmapNodeRepository.deleteRoadmapNodesByRoadmapId_Id(roadmapId);
+    public boolean deleteRoadmapCategory(long roadmapId) {
+        if (roadmapNodeRepository.findAllByRoadmapId_Id(roadmapId).size() > 0) {
+            roadmapEdgeRepository.deleteRoadmapEdgesByRoadmapId_Id(roadmapId);
+            roadmapNodeRepository.deleteRoadmapNodesByRoadmapId_Id(roadmapId);
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/main/java/com/darknights/devigation/roadmap/command/application/service/DeleteRoadmapCategoryService.java
+++ b/src/main/java/com/darknights/devigation/roadmap/command/application/service/DeleteRoadmapCategoryService.java
@@ -1,0 +1,25 @@
+package com.darknights.devigation.roadmap.command.application.service;
+
+import com.darknights.devigation.roadmap.command.domain.RoadmapRepository.RoadmapEdgeRepository;
+import com.darknights.devigation.roadmap.command.domain.RoadmapRepository.RoadmapNodeRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class DeleteRoadmapCategoryService {
+    private final RoadmapEdgeRepository roadmapEdgeRepository;
+    private final RoadmapNodeRepository roadmapNodeRepository;
+
+    @Autowired
+    public DeleteRoadmapCategoryService(RoadmapEdgeRepository roadmapEdgeRepository, RoadmapNodeRepository roadmapNodeRepository) {
+        this.roadmapEdgeRepository = roadmapEdgeRepository;
+        this.roadmapNodeRepository = roadmapNodeRepository;
+    }
+
+    @Transactional
+    public void deleteRoadmapCategory(long roadmapId){
+        roadmapEdgeRepository.deleteRoadmapEdgesByRoadmapId_Id(roadmapId);
+        roadmapNodeRepository.deleteRoadmapNodesByRoadmapId_Id(roadmapId);
+    }
+}

--- a/src/main/java/com/darknights/devigation/roadmap/command/application/service/UpdateRoadmapCategoryService.java
+++ b/src/main/java/com/darknights/devigation/roadmap/command/application/service/UpdateRoadmapCategoryService.java
@@ -1,0 +1,31 @@
+package com.darknights.devigation.roadmap.command.application.service;
+
+import com.darknights.devigation.roadmap.command.application.dto.CreateEdgeDTO;
+import com.darknights.devigation.roadmap.command.application.dto.CreateNodeDTO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class UpdateRoadmapCategoryService {
+    private final CreateRoadmapCategoryService createRoadmapCategoryService;
+    private final DeleteRoadmapCategoryService deleteRoadmapCategoryService;
+
+
+    @Autowired
+    public UpdateRoadmapCategoryService(CreateRoadmapCategoryService createRoadmapCategoryService, DeleteRoadmapCategoryService deleteRoadmapCategoryService) {
+        this.createRoadmapCategoryService = createRoadmapCategoryService;
+        this.deleteRoadmapCategoryService = deleteRoadmapCategoryService;
+    }
+
+    @Transactional
+    public boolean updateRoadmapCategory(List<CreateNodeDTO> createNodeDTOS, List<CreateEdgeDTO> createEdgeDTOS, long roadmapId){
+        deleteRoadmapCategoryService.deleteRoadmapCategory(roadmapId);
+        createRoadmapCategoryService.createRoadmapCategory(createNodeDTOS,createEdgeDTOS);
+
+
+        return true;
+    }
+}

--- a/src/main/java/com/darknights/devigation/roadmap/command/application/service/UpdateRoadmapCategoryService.java
+++ b/src/main/java/com/darknights/devigation/roadmap/command/application/service/UpdateRoadmapCategoryService.java
@@ -22,10 +22,9 @@ public class UpdateRoadmapCategoryService {
 
     @Transactional
     public boolean updateRoadmapCategory(List<CreateNodeDTO> createNodeDTOS, List<CreateEdgeDTO> createEdgeDTOS, long roadmapId){
-        deleteRoadmapCategoryService.deleteRoadmapCategory(roadmapId);
-        createRoadmapCategoryService.createRoadmapCategory(createNodeDTOS,createEdgeDTOS);
-
-
+        if(deleteRoadmapCategoryService.deleteRoadmapCategory(roadmapId)){
+            if(createRoadmapCategoryService.createRoadmapCategory(createNodeDTOS,createEdgeDTOS))return true;
+        }
         return true;
     }
 }

--- a/src/main/java/com/darknights/devigation/roadmap/command/domain/RoadmapRepository/RoadmapEdgeRepository.java
+++ b/src/main/java/com/darknights/devigation/roadmap/command/domain/RoadmapRepository/RoadmapEdgeRepository.java
@@ -3,5 +3,9 @@ package com.darknights.devigation.roadmap.command.domain.RoadmapRepository;
 import com.darknights.devigation.roadmap.command.domain.aggregate.entity.RoadmapEdge;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface RoadmapEdgeRepository extends JpaRepository<RoadmapEdge,Long> {
+    void deleteRoadmapEdgesByRoadmapId_Id(long roadmapId);
+    Optional<RoadmapEdge> findAllByRoadmapId_Id(long roadmapId);
 }

--- a/src/main/java/com/darknights/devigation/roadmap/command/domain/RoadmapRepository/RoadmapEdgeRepository.java
+++ b/src/main/java/com/darknights/devigation/roadmap/command/domain/RoadmapRepository/RoadmapEdgeRepository.java
@@ -3,9 +3,10 @@ package com.darknights.devigation.roadmap.command.domain.RoadmapRepository;
 import com.darknights.devigation.roadmap.command.domain.aggregate.entity.RoadmapEdge;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface RoadmapEdgeRepository extends JpaRepository<RoadmapEdge,Long> {
     void deleteRoadmapEdgesByRoadmapId_Id(long roadmapId);
-    Optional<RoadmapEdge> findAllByRoadmapId_Id(long roadmapId);
+    List<Optional<RoadmapEdge>> findAllByRoadmapId_Id(long roadmapId);
 }

--- a/src/main/java/com/darknights/devigation/roadmap/command/domain/RoadmapRepository/RoadmapNodeRepository.java
+++ b/src/main/java/com/darknights/devigation/roadmap/command/domain/RoadmapRepository/RoadmapNodeRepository.java
@@ -9,5 +9,5 @@ import java.util.Optional;
 
 public interface RoadmapNodeRepository extends JpaRepository<RoadmapNode,Long> {
     void deleteRoadmapNodesByRoadmapId_Id(long roadmapId);
-    Optional<RoadmapNode> findAllByRoadmapId_Id(long roadmapId);
+    List<Optional<RoadmapNode>> findAllByRoadmapId_Id(long roadmapId);
 }

--- a/src/main/java/com/darknights/devigation/roadmap/command/domain/RoadmapRepository/RoadmapNodeRepository.java
+++ b/src/main/java/com/darknights/devigation/roadmap/command/domain/RoadmapRepository/RoadmapNodeRepository.java
@@ -1,5 +1,6 @@
 package com.darknights.devigation.roadmap.command.domain.RoadmapRepository;
 
+import com.darknights.devigation.roadmap.command.domain.aggregate.entity.RoadmapEdge;
 import com.darknights.devigation.roadmap.command.domain.aggregate.entity.RoadmapNode;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -7,4 +8,6 @@ import java.util.List;
 import java.util.Optional;
 
 public interface RoadmapNodeRepository extends JpaRepository<RoadmapNode,Long> {
+    void deleteRoadmapNodesByRoadmapId_Id(long roadmapId);
+    Optional<RoadmapNode> findAllByRoadmapId_Id(long roadmapId);
 }

--- a/src/main/java/com/darknights/devigation/roadmap/command/domain/aggregate/entity/RoadmapNode.java
+++ b/src/main/java/com/darknights/devigation/roadmap/command/domain/aggregate/entity/RoadmapNode.java
@@ -5,6 +5,7 @@ import com.darknights.devigation.roadmap.command.domain.aggregate.vo.CategoryVO;
 import com.darknights.devigation.roadmap.command.domain.aggregate.vo.RoadmapVO;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import javax.persistence.*;
 
@@ -12,6 +13,7 @@ import javax.persistence.*;
 @Table(name="ROADMAP_NODE_TB")
 @NoArgsConstructor
 @Getter
+@ToString
 public class RoadmapNode {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/test/java/com/darknights/devigation/roadmap/service/RoadmapCategoryServiceTests.java
+++ b/src/test/java/com/darknights/devigation/roadmap/service/RoadmapCategoryServiceTests.java
@@ -3,6 +3,8 @@ package com.darknights.devigation.roadmap.service;
 import com.darknights.devigation.roadmap.command.application.dto.CreateEdgeDTO;
 import com.darknights.devigation.roadmap.command.application.dto.CreateNodeDTO;
 import com.darknights.devigation.roadmap.command.application.service.CreateRoadmapCategoryService;
+import com.darknights.devigation.roadmap.command.application.service.DeleteRoadmapCategoryService;
+import com.darknights.devigation.roadmap.command.domain.RoadmapRepository.RoadmapEdgeRepository;
 import com.darknights.devigation.roadmap.command.domain.RoadmapRepository.RoadmapNodeRepository;
 import com.darknights.devigation.roadmap.query.domain.repository.RoadmapCategoryMapper;
 import org.junit.jupiter.api.Assertions;
@@ -22,6 +24,12 @@ public class RoadmapCategoryServiceTests {
 
     @Autowired
     private CreateRoadmapCategoryService createRoadmapCategoryService;
+    @Autowired
+    private DeleteRoadmapCategoryService deleteRoadmapCategoryService;
+    @Autowired
+    private RoadmapEdgeRepository roadmapEdgeRepository;
+    @Autowired
+    private RoadmapNodeRepository roadmapNodeRepository;
 
     private static Stream<Arguments> getRoadmapCategory() {
         return Stream.of(
@@ -40,11 +48,40 @@ public class RoadmapCategoryServiceTests {
         );
     }
 
+    private static Stream<Arguments> deleteRoadmapCategory() {
+        return Stream.of(
+                Arguments.arguments(Arrays.asList(
+                                new CreateNodeDTO(1, 1, "100 200"),
+                                new CreateNodeDTO(1, 2, "100 300"),
+                                new CreateNodeDTO(1, 3, "100 400")
+                        ),
+                        Arrays.asList(
+                                new CreateEdgeDTO(1, "edge 1", 1, 2),
+                                new CreateEdgeDTO(1, "edge 2", 2, 3)
+
+                        ), 1
+
+                )
+        );
+    }
+
+
+
+
 
     @ParameterizedTest
     @DisplayName("로드맵 카테고리 생성 테스트")
     @MethodSource("getRoadmapCategory")
-    public void CreateRoadmapCategoryTest(List<CreateNodeDTO> createNodeDTOS, List<CreateEdgeDTO> createEdgeDTOS) {
+    public void createRoadmapCategoryTest(List<CreateNodeDTO> createNodeDTOS, List<CreateEdgeDTO> createEdgeDTOS) {
         Assertions.assertTrue(createRoadmapCategoryService.createRoadmapCategory(createNodeDTOS,createEdgeDTOS));
+    }
+
+    @ParameterizedTest
+    @DisplayName("로드맵 카테고리 삭제 테스트")
+    @MethodSource("deleteRoadmapCategory")
+    public void DeleteRoadmapCategoryTest(List<CreateNodeDTO> createNodeDTOS, List<CreateEdgeDTO> createEdgeDTOS, long roadmapId){
+        createRoadmapCategoryService.createRoadmapCategory(createNodeDTOS,createEdgeDTOS);
+        deleteRoadmapCategoryService.deleteRoadmapCategory(roadmapId);
+        Assertions.assertTrue(roadmapEdgeRepository.findAllByRoadmapId_Id(roadmapId).isEmpty()&&roadmapNodeRepository.findAllByRoadmapId_Id(roadmapId).isEmpty());
     }
 }

--- a/src/test/java/com/darknights/devigation/roadmap/service/RoadmapCategoryServiceTests.java
+++ b/src/test/java/com/darknights/devigation/roadmap/service/RoadmapCategoryServiceTests.java
@@ -4,8 +4,10 @@ import com.darknights.devigation.roadmap.command.application.dto.CreateEdgeDTO;
 import com.darknights.devigation.roadmap.command.application.dto.CreateNodeDTO;
 import com.darknights.devigation.roadmap.command.application.service.CreateRoadmapCategoryService;
 import com.darknights.devigation.roadmap.command.application.service.DeleteRoadmapCategoryService;
+import com.darknights.devigation.roadmap.command.application.service.UpdateRoadmapCategoryService;
 import com.darknights.devigation.roadmap.command.domain.RoadmapRepository.RoadmapEdgeRepository;
 import com.darknights.devigation.roadmap.command.domain.RoadmapRepository.RoadmapNodeRepository;
+import com.darknights.devigation.roadmap.command.domain.service.RoadmapCategoryService;
 import com.darknights.devigation.roadmap.query.domain.repository.RoadmapCategoryMapper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -30,6 +32,8 @@ public class RoadmapCategoryServiceTests {
     private RoadmapEdgeRepository roadmapEdgeRepository;
     @Autowired
     private RoadmapNodeRepository roadmapNodeRepository;
+    @Autowired
+    private UpdateRoadmapCategoryService updateRoadmapCategoryService;
 
     private static Stream<Arguments> getRoadmapCategory() {
         return Stream.of(
@@ -65,6 +69,34 @@ public class RoadmapCategoryServiceTests {
         );
     }
 
+    private static Stream<Arguments> updateRoadmapCategory() {
+        return Stream.of(
+                Arguments.arguments(
+                        Arrays.asList(
+                                new CreateNodeDTO(1, 1, "100 200"),
+                                new CreateNodeDTO(1, 2, "100 300"),
+                                new CreateNodeDTO(1, 3, "100 400")
+                        ),
+                        Arrays.asList(
+                                new CreateEdgeDTO(1, "edge 1", 1, 2),
+                                new CreateEdgeDTO(1, "edge 2", 2, 3)
+
+                        ),
+                        Arrays.asList(
+                                new CreateNodeDTO(1, 4, "150 250"),
+                                new CreateNodeDTO(1, 5, "150 350"),
+                                new CreateNodeDTO(1, 6, "150 450")
+                        ),
+                        Arrays.asList(
+                                new CreateEdgeDTO(1, "edge 1", 1, 2),
+                                new CreateEdgeDTO(1, "edge 2", 2, 3)
+
+                        ), 1
+
+                )
+        );
+    }
+
 
 
 
@@ -79,9 +111,17 @@ public class RoadmapCategoryServiceTests {
     @ParameterizedTest
     @DisplayName("로드맵 카테고리 삭제 테스트")
     @MethodSource("deleteRoadmapCategory")
-    public void DeleteRoadmapCategoryTest(List<CreateNodeDTO> createNodeDTOS, List<CreateEdgeDTO> createEdgeDTOS, long roadmapId){
+    public void deleteRoadmapCategoryTest(List<CreateNodeDTO> createNodeDTOS, List<CreateEdgeDTO> createEdgeDTOS, long roadmapId){
         createRoadmapCategoryService.createRoadmapCategory(createNodeDTOS,createEdgeDTOS);
         deleteRoadmapCategoryService.deleteRoadmapCategory(roadmapId);
-        Assertions.assertTrue(roadmapEdgeRepository.findAllByRoadmapId_Id(roadmapId).isEmpty()&&roadmapNodeRepository.findAllByRoadmapId_Id(roadmapId).isEmpty());
+        Assertions.assertTrue(roadmapEdgeRepository.findAllByRoadmapId_Id(roadmapId).size()==0&&roadmapNodeRepository.findAllByRoadmapId_Id(roadmapId).size()==0);
+    }
+
+    @ParameterizedTest
+    @DisplayName("로드맵 카테고리 수정 테스트")
+    @MethodSource("updateRoadmapCategory")
+    public void updateRoadmapCategorytTest(List<CreateNodeDTO> createNodeDTOS, List<CreateEdgeDTO> createEdgeDTOS, List<CreateNodeDTO> updateNodeDTOS, List<CreateEdgeDTO> updateEdgeDTOS,long roadmapId ){
+        createRoadmapCategoryService.createRoadmapCategory(createNodeDTOS,createEdgeDTOS);
+        Assertions.assertTrue( updateRoadmapCategoryService.updateRoadmapCategory(updateNodeDTOS,updateEdgeDTOS,roadmapId));
     }
 }


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #66 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 없음
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* roadmap category의 delete기능과 update기능을 추가했습니다.
* roadmap category의 update는 기존의 있던 roadmap category의 정보를 전부 삭제하고 다시 새롭게 모든 category를 insert하는 방식으로 진행됩니다.
---

# 관련 스크린샷

---
* 없음
---

# 테스트 계획 또는 완료 사항

---
* <img width="405" alt="image" src="https://github.com/The-Dark-Nights/back-end/assets/74136791/ce4994ee-b621-4485-9df5-41d57aacb504">
