### PR TITLE
[closes #80] 업로드 중 사진 이외에 파일 예외처리

### DIFF
--- a/src/main/java/com/darknights/devigation/aws/command/application/service/AwsS3Service.java
+++ b/src/main/java/com/darknights/devigation/aws/command/application/service/AwsS3Service.java
@@ -71,7 +71,7 @@ public class AwsS3Service {
 
     private String getFileExtension(String fileName) {
         String extension = fileName.substring(fileName.lastIndexOf("."));
-        if (extension.equals(".png") || extension.equals(".jpg") || extension.equals(".jpeg")) {
+        if (extension.equals(".png") || extension.equals(".jpg") || extension.equals(".jpeg") || extension.equals(".gif")) {
             return extension;
         }
         return null;

--- a/src/main/java/com/darknights/devigation/aws/command/application/service/AwsS3Service.java
+++ b/src/main/java/com/darknights/devigation/aws/command/application/service/AwsS3Service.java
@@ -19,11 +19,10 @@ public class AwsS3Service {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    @Autowired
-    private final AmazonS3Client amazonS3Client ;
+    private final AmazonS3Client amazonS3Client;
 
     @Autowired
-    public AwsS3Service (AmazonS3Client amazonS3Client){
+    public AwsS3Service(AmazonS3Client amazonS3Client) {
         this.amazonS3Client = amazonS3Client;
     }
 
@@ -39,7 +38,7 @@ public class AwsS3Service {
         // Spring Server에서 S3로 파일을 업로드하기 위해
         // 이때의 파일 사이즈와 파일 타입을 알려주기 위해 ObjectMetadata사용
 
-        String url=null;
+        String url = null;
         try (InputStream inputStream = multipartFiles.getInputStream()) {
             // InputStream을 사용해 파일의 데이터 읽음
 
@@ -48,31 +47,34 @@ public class AwsS3Service {
             amazonS3Client.putObject(uploadFile);
             // 객체를 생성해 S3에 전송, withCannedAcl => 파일을 공개 읽기 권한으로 설정
 
-            url = String.valueOf(amazonS3Client.getUrl(bucket,uploadFile.getKey()));
+            url = String.valueOf(amazonS3Client.getUrl(bucket, uploadFile.getKey()));
 
         } catch (IOException e) {
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
                     "이미지 업로드에 실패했습니다.");
+            // 수정 해당 Exception은 추후@RestControllerAdvice와 Assert에서 통합 관리하면 좋을 거 같습니다
         }
         // S3에 저장된 fileNameList(즉, UUID로 변환된 fileNameList)
-
 
 
         return url;
     }
 
     private String createFileName(String fileName) {
-        return UUID.randomUUID().toString().concat(getFileExtension(fileName));
-        // 파일 이름이 증복되지 않게 하기 위해 랜덤으로 UUID 생성
+        try {
+            return UUID.randomUUID().toString().concat(getFileExtension(fileName));
+            // 파일 이름이 증복되지 않게 하기 위해 랜덤으로 UUID 생성
+        } catch (NullPointerException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "잘못된 형식의 파일 확장자(" + fileName + ")입니다.");
+        }
     }
 
     private String getFileExtension(String fileName) {
-        try {
-            return fileName.substring(fileName.lastIndexOf("."));
-            // 확장자 ex) asd.png 일 때 확장자 전까지 파일 이름을 반환
-        } catch (StringIndexOutOfBoundsException e) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "잘못된 형식의 파일(" + fileName + ")입니다.");
+        String extension = fileName.substring(fileName.lastIndexOf("."));
+        if (extension.equals(".png") || extension.equals(".jpg") || extension.equals(".jpeg")) {
+            return extension;
         }
+        return null;
     }
 
     public void deleteImage(String fileName) {


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #80
* Amazon S3에 사진 파일 이외에 다른 파일 전부 업로드 되는 상황을 발견해서 사진 파일만 업로드 할 수 있도록 수정했습니다. 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 없음
---

# 관련 스크린샷

---
* 정해 놓은 사진 파일 확장자( png, jpg, jpeg)가 아닐 경우 예외가 발생하도록 했습니다.

<img width="418" alt="image" src="https://github.com/The-Dark-Nights/back-end/assets/136034038/40a5bd7d-e3f4-48af-bd5f-129785067464">

* docx파일을 업로드 할시 예외 처리되는 것을 확인할 수 있습니다.
---

# 테스트 계획 또는 완료 사항

---
<img width="976" alt="image" src="https://github.com/The-Dark-Nights/back-end/assets/136034038/4ca40ea3-5572-47c1-bcca-73a21db7ca21">

* 기존 테스트 코드 또한 정상작동하는 것을 확인할 수 있습니다.
