### PR TITLE
[Closes #86] Refactor : Spring Security 통합 테스트

### DIFF
--- a/src/main/java/com/darknights/devigation/domain/admin/command/application/AdminController.java
+++ b/src/main/java/com/darknights/devigation/domain/admin/command/application/AdminController.java
@@ -1,16 +1,19 @@
 package com.darknights.devigation.domain.admin.command.application;
 
 
+import com.darknights.devigation.global.common.annotation.CurrentMember;
+import com.darknights.devigation.global.security.token.UserPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/admin")
+@RequestMapping(value = "/admin")
 public class AdminController {
 
-    @GetMapping("/")
-    public String test() {
+    @GetMapping
+    public String test(@CurrentMember UserPrincipal userPrincipal) {
+        System.out.println("userPrincipal.getName() = " + userPrincipal.getName());
         return "test";
     }
 }

--- a/src/main/java/com/darknights/devigation/global/security/command/application/service/CustomUserDetailService.java
+++ b/src/main/java/com/darknights/devigation/global/security/command/application/service/CustomUserDetailService.java
@@ -23,6 +23,7 @@ public class CustomUserDetailService implements UserDetailsService {
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
 
         FindMemberDTO member = findMemberService.findByEmail(email);
+        System.out.println("member = " + member);
         return UserPrincipal.create(member);
     }
 

--- a/src/test/java/com/darknights/devigation/domain/admin/command/application/AdminControllerTest.java
+++ b/src/test/java/com/darknights/devigation/domain/admin/command/application/AdminControllerTest.java
@@ -1,0 +1,98 @@
+package com.darknights.devigation.domain.admin.command.application;
+
+import com.darknights.devigation.domain.member.command.domain.aggregate.entity.enumType.PlatformEnum;
+import com.darknights.devigation.domain.member.command.domain.aggregate.entity.enumType.Role;
+import com.darknights.devigation.domain.member.query.application.dto.FindMemberDTO;
+import com.darknights.devigation.domain.member.query.application.service.FindMemberService;
+import com.darknights.devigation.global.common.WithMockCustomUser;
+import com.darknights.devigation.global.filter.TokenAuthenticationFilter;
+import com.darknights.devigation.global.security.command.application.service.CustomUserDetailService;
+import com.darknights.devigation.global.security.command.domain.service.CustomTokenService;
+import com.darknights.devigation.global.security.token.UserPrincipal;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.Arrays;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class AdminControllerTest {
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    private FindMemberService findMemberService;
+
+    @Autowired
+    private CustomTokenService customTokenService;
+
+    @Autowired
+    private CustomUserDetailService customUserDetailService;
+
+    @BeforeEach
+    public void setup() {
+        // mvc
+
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply(springSecurity())
+                .addFilter(new TokenAuthenticationFilter(customTokenService, customUserDetailService))
+                .build();
+
+        System.out.println(webApplicationContext.getBean("adminController"));
+
+    }
+
+    @DisplayName("임시 정보를 통해 JWT 토큰 검증 테스트")
+    @WithMockCustomUser(email = "email@test.com", role = "ADMIN")
+    @Test
+    void testGetMethodWithJwt() throws Exception {
+
+        UserPrincipal userPrincipal = (UserPrincipal) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String testToken = customTokenService.createToken(userPrincipal.getId(), userPrincipal.getRole());
+
+        FindMemberDTO mockFindMemberDTO = new FindMemberDTO(
+                userPrincipal.getId(),
+                "mockName",
+                "email@test.com",
+                "profileImage",
+                PlatformEnum.GITHUB.name(),
+                Role.valueOf(userPrincipal.getRole().substring(5)).name()
+        );
+        when(findMemberService.findById(userPrincipal.getId())).thenReturn(mockFindMemberDTO);
+        System.out.println("testToken = " + testToken);
+
+        mockMvc.perform(
+                get("/admin")
+                        .header("Authorization", "Bearer " + testToken)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+        )
+                .andDo(print())
+                .andExpect(
+                status().isOk()
+        );
+    }
+}

--- a/src/test/java/com/darknights/devigation/global/common/WithMockCustomUser.java
+++ b/src/test/java/com/darknights/devigation/global/common/WithMockCustomUser.java
@@ -1,0 +1,15 @@
+package com.darknights.devigation.global.common;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)
+public @interface WithMockCustomUser {
+
+    String email() default "first";
+    String role() default "MEMBER";
+    String provider() default "GITHUB";
+}

--- a/src/test/java/com/darknights/devigation/global/common/WithMockCustomUserSecurityContextFactory.java
+++ b/src/test/java/com/darknights/devigation/global/common/WithMockCustomUserSecurityContextFactory.java
@@ -1,0 +1,34 @@
+package com.darknights.devigation.global.common;
+
+import com.darknights.devigation.domain.member.command.domain.aggregate.entity.enumType.PlatformEnum;
+import com.darknights.devigation.domain.member.command.domain.aggregate.entity.enumType.Role;
+import com.darknights.devigation.domain.member.query.application.dto.FindMemberDTO;
+import com.darknights.devigation.global.security.token.UserPrincipal;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithMockCustomUserSecurityContextFactory implements WithSecurityContextFactory<WithMockCustomUser> {
+    @Override
+    public SecurityContext createSecurityContext(WithMockCustomUser annotation) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+
+        FindMemberDTO mockFindMemberDTO = new FindMemberDTO(
+                0L,
+                "mockName",
+                annotation.email(),
+                "profileImage",
+                annotation.provider(),
+                annotation.role()
+        );
+
+        UserPrincipal principal = UserPrincipal.create(mockFindMemberDTO);
+        Authentication auth = new UsernamePasswordAuthenticationToken(principal, principal.getPassword(), principal.getAuthorities());
+        context.setAuthentication(auth);
+        return context;
+    }
+}


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #86 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 기존의 Spring Security 통합 테스트에서 임시 사용자를 주입하는 방법에 대해 Security에서 제공하는 어노테이션을 사용하여 구현하라는 피드백이 있어 반영하였습니다.
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* `@WithMockCustomUser` 을 통해 테스트에서 사용할 임시 사용자 정보를 추가합니다.
* `WithMockCustomUserSecurityContextFactory` 클래스를 통해 `@WithMockCustomUser`에서 입력한 사용자 정보를 MockMvc에 설정한 security context holder에 인증 사용자 정보를 주입합니다.
* 토큰 검증 필터에서 테스트용으로 발급된 JWT 토큰을 유효성 검사를 한 후, 토큰 내부의 Id를 가진 사용자가 존재하는지 확인하는 과정을 테스트 시 사용자가 있는 것처럼 하기 위해 `when` , `thenReturn` 메서드를 사용하였습니다.
---

# 관련 스크린샷

---
* 없음
---

# 테스트 계획 또는 완료 사항
![CleanShot 2023-09-14 at 09 29 27](https://github.com/The-Dark-Nights/back-end/assets/19159759/3d45bfe0-97f9-4e71-9812-cb7db81d8b3a)


---
* 임시 정보를 통해 JWT 토큰 검증 테스트를 완료하였습니다.
