### PR TITLE
[closes #93] 글 조회 기능 구현

### DIFF
--- a/src/main/java/com/darknights/devigation/domain/post/command/application/dto/CreatePostDTO.java
+++ b/src/main/java/com/darknights/devigation/domain/post/command/application/dto/CreatePostDTO.java
@@ -13,4 +13,14 @@ public class CreatePostDTO {
     private Long categoryId;
     private String content;
     private boolean published;
+
+    public CreatePostDTO() {}
+
+    public CreatePostDTO(String title, Long memberId, Long categoryId, String content, boolean published) {
+        this.title = title;
+        this.memberId = memberId;
+        this.categoryId = categoryId;
+        this.content = content;
+        this.published = published;
+    }
 }

--- a/src/main/java/com/darknights/devigation/domain/post/query/application/dto/FindPostDTO.java
+++ b/src/main/java/com/darknights/devigation/domain/post/query/application/dto/FindPostDTO.java
@@ -1,0 +1,36 @@
+package com.darknights.devigation.domain.post.query.application.dto;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class FindPostDTO {
+
+    private Long id;
+
+    private String title;
+
+    private Long memberId;
+
+    private Long categoryId;
+
+    private String content;
+
+    private LocalDateTime createdDate;
+
+    private boolean published;
+
+    @Override
+    public String toString() {
+        return "FindPostDTO{" +
+                "id=" + id +
+                ", title='" + title + '\'' +
+                ", memberId=" + memberId +
+                ", categoryId=" + categoryId +
+                ", content='" + content + '\'' +
+                ", createdDate=" + createdDate +
+                ", published=" + published +
+                '}';
+    }
+}

--- a/src/main/java/com/darknights/devigation/domain/post/query/application/service/FindPostService.java
+++ b/src/main/java/com/darknights/devigation/domain/post/query/application/service/FindPostService.java
@@ -1,0 +1,40 @@
+package com.darknights.devigation.domain.post.query.application.service;
+
+import com.darknights.devigation.domain.post.query.application.dto.FindPostDTO;
+import com.darknights.devigation.domain.post.query.domain.repository.PostMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class FindPostService {
+
+    private final PostMapper postMapper;
+
+    @Autowired
+    public FindPostService(PostMapper postMapper) {
+        this.postMapper = postMapper;
+    }
+
+    public List<FindPostDTO> findAll(){
+        return postMapper.findAll();
+    }
+
+    public List<FindPostDTO> findByMemberId(Long memberId){
+
+        return postMapper.findByMemberId(memberId);
+    }
+
+    public FindPostDTO findById(Long id){
+        return postMapper.findById(id);
+    }
+
+    public List<FindPostDTO> findByContent(String searchWord){
+        return postMapper.findByContent(searchWord);
+    }
+    public List<FindPostDTO> findByTitle(String searchWord){
+        return postMapper.findByTitle(searchWord);
+    }
+
+}

--- a/src/main/java/com/darknights/devigation/domain/post/query/domain/repository/PostMapper.java
+++ b/src/main/java/com/darknights/devigation/domain/post/query/domain/repository/PostMapper.java
@@ -1,0 +1,24 @@
+package com.darknights.devigation.domain.post.query.domain.repository;
+
+import com.darknights.devigation.domain.post.query.application.dto.FindPostDTO;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface PostMapper {
+
+    List<FindPostDTO> findAll();
+
+    // memberId별 조회 ( 마이페이지 - 발행여부 상관 없음)
+    List<FindPostDTO> findByMemberId(Long memberId);
+
+    //상세조회
+    FindPostDTO findById(Long id);
+
+    //내용 검색 기능
+    List<FindPostDTO> findByContent(String searchWord);
+
+    // 제목 검색 기능
+    List<FindPostDTO> findByTitle(String searchWord);
+}

--- a/src/main/resources/mapper/post/PostMapper.xml
+++ b/src/main/resources/mapper/post/PostMapper.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.darknights.devigation.domain.post.query.domain.repository.PostMapper">
+    <resultMap id="QueryPostMap" type="com.darknights.devigation.domain.post.query.application.dto.FindPostDTO">
+        <id property="id" column="id"/>
+        <result property="title" column="title"/>
+        <result property="memberId" column="member_id"/>
+        <result property="categoryId" column="category_id"/>
+        <result property="content" column="content"/>
+        <result property="created_date" column="createDate"/>
+        <result property="published" column="published"/>
+    </resultMap>
+
+    <select id="findAll" resultMap="QueryPostMap">
+        SELECT *
+        FROM
+            POST_TB
+        WHERE published = 1
+    </select>
+
+    <select id="findByMemberId" resultMap="QueryPostMap">
+        SELECT *
+        FROM
+            POST_TB
+        WHERE member_id = #{memberId}
+    </select>
+
+    <select id="findById" resultMap="QueryPostMap">
+        SELECT *
+        FROM
+            POST_TB
+        WHERE id =#{id}
+    </select>
+
+    <select id="findByContent" resultMap="QueryPostMap">
+        SELECT *
+        FROM
+            POST_TB
+        WHERE content LIKE concat ('%', #{searchWord}, '%')
+    </select>
+
+    <select id="findByTitle" resultMap="QueryPostMap">
+        SELECT *
+        FROM
+            POST_TB
+        WHERE title LIKE concat ('%', #{searchWord}, '%')
+    </select>
+
+</mapper>

--- a/src/test/java/com/darknights/devigation/domain/post/query/service/PostReadTests.java
+++ b/src/test/java/com/darknights/devigation/domain/post/query/service/PostReadTests.java
@@ -1,0 +1,163 @@
+package com.darknights.devigation.domain.post.query.service;
+
+import com.darknights.devigation.domain.post.command.application.dto.CreatePostDTO;
+import com.darknights.devigation.domain.post.command.application.service.CreatePostService;
+import com.darknights.devigation.domain.post.command.application.service.DeletePostService;
+import com.darknights.devigation.domain.post.command.domain.aggregate.entity.Post;
+import com.darknights.devigation.domain.post.query.application.dto.FindPostDTO;
+import com.darknights.devigation.domain.post.query.application.service.FindPostService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+@SpringBootTest
+public class PostReadTests {
+
+    @Autowired
+    private CreatePostService createPostService;
+
+    @Autowired
+    private DeletePostService deletePostService;
+
+    @Autowired
+    private FindPostService findPostService;
+
+    private static Stream<Arguments> createPost() {
+        return Stream.of(
+                Arguments.of(
+                        new CreatePostDTO(
+                                "테스트용 제목 1번, testTitle_1",
+                                1L,
+                                1L,
+                                "테스트용 내용 1번, testContent_1",
+                                true
+                        ),
+                        new CreatePostDTO(
+                                "테스트용 제목 2번, testTitle_2",
+                                1L,
+                                1L,
+                                "테스트용 내용 2번, testContent_2",
+                                true
+                        ),
+                        new CreatePostDTO(
+                                "테스트용 제목 3번, testTitle_3",
+                                2L,
+                                1L,
+                                "테스트용 내용 3번, testContent_3",
+                                true
+                        )
+                )
+        );
+    }
+
+    Long postId_1;
+    Long postId_2;
+    Long postId_3;
+
+    @AfterEach
+    void deletePost() {
+        if (postId_3 != null) {
+            deletePostService.deletePost(postId_1);
+            deletePostService.deletePost(postId_2);
+            deletePostService.deletePost(postId_3);
+        } else {
+            deletePostService.deletePost(postId_1);
+        }
+        postId_1 = null;
+        postId_2 = null;
+        postId_3 = null;
+    }
+
+    @DisplayName("글 전체 조회 테스트")
+    @ParameterizedTest
+    @MethodSource("createPost")
+    void findAllTest(CreatePostDTO postDTO1, CreatePostDTO postDTO2, CreatePostDTO postDTO3) {
+        //given
+        int beforeSize = findPostService.findAll().size();
+        Post post1 = createPostService.createPost(postDTO1);
+        Post post2 = createPostService.createPost(postDTO2);
+        Post post3 = createPostService.createPost(postDTO3);
+        postId_1 = post1.getId();
+        postId_2 = post2.getId();
+        postId_3 = post3.getId();
+
+        //when
+        List<FindPostDTO> posts = findPostService.findAll();
+        int afterSize = posts.size();
+
+        //then
+        Assertions.assertNotNull(posts);
+        Assertions.assertNotEquals(beforeSize, afterSize);
+        Assertions.assertEquals(beforeSize + 3, afterSize);
+    }
+
+    @DisplayName("memberId 별 글 조회 테스트")
+    @ParameterizedTest
+    @MethodSource("createPost")
+    void findByMemberIdTest(CreatePostDTO postDTO1, CreatePostDTO postDTO2, CreatePostDTO postDTO3){
+        //given
+        Post post1 = createPostService.createPost(postDTO1);
+        Post post2 = createPostService.createPost(postDTO2);
+        Post post3 = createPostService.createPost(postDTO3);
+        postId_1 = post1.getId();
+        postId_2 = post2.getId();
+        postId_3 = post3.getId();
+        Long member = post1.getMemberId().getId();
+        Long notMember = post3.getMemberId().getId();
+        //when
+        List<FindPostDTO> posts= findPostService.findByMemberId(post1.getMemberId().getId());
+
+        //then
+        Assertions.assertNotNull(posts);
+        Assertions.assertEquals(member,posts.get(0).getMemberId());
+        Assertions.assertNotEquals(notMember,posts.get(0).getMemberId());
+
+    }
+
+    @DisplayName("id로 글 조회 (상세보기) 테스트")
+    @ParameterizedTest
+    @MethodSource("createPost")
+    void findByIdTest(CreatePostDTO postDTO1){
+        //given
+        Post post1 = createPostService.createPost(postDTO1);
+        postId_1 = post1.getId();
+
+        //when
+        FindPostDTO post = findPostService.findById(post1.getId());
+
+        //then
+        Assertions.assertNotNull(post);
+        Assertions.assertEquals(postId_1, post.getId());
+
+    }
+
+    @DisplayName("제목 및 내용으로 검색 기능 테스트")
+    @ParameterizedTest
+    @MethodSource("createPost")
+    void findByTitle(CreatePostDTO postDTO1){
+        //given
+        Post post1 = createPostService.createPost(postDTO1);
+        postId_1 = post1.getId();
+        String searchTitle_kr = "제목 1번";
+//        String searchTitle_en = "Title_1";
+
+        String searchContent_kr ="내용 1번";
+//        String searchContent_en ="Content_1";
+        //when
+        List<FindPostDTO> findPost1 = findPostService.findByTitle(searchTitle_kr);
+        List<FindPostDTO> findPost2 = findPostService.findByContent(searchContent_kr);
+        //then
+        Assertions.assertNotNull(findPost1);
+        Assertions.assertNotNull(findPost2);
+        Assertions.assertEquals(findPost1.get(0).getId(), findPost2.get(0).getId());
+
+    }
+}


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #93 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 없음
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
```
  @DisplayName("id로 글 조회 (상세보기) 테스트") 
  @ParameterizedTest
  @MethodSource("createPost")
  void findByIdTest(CreatePostDTO postDTO1){
        //given
        Post post1 = createPostService.createPost(postDTO1);
        postId_1 = post1.getId();

        //when
        FindPostDTO post = findPostService.findById(post1.getId());

        //then
        Assertions.assertNotNull(post);
        Assertions.assertEquals(postId_1, post.getId());

    }
```
    @AfterEach
    void deletePost() {
        if (postId_3 != null) {
            deletePostService.deletePost(postId_1);
            deletePostService.deletePost(postId_2);
            deletePostService.deletePost(postId_3);
        } else {
            deletePostService.deletePost(postId_1);
        }
        postId_1 = null;
        postId_2 = null;
        postId_3 = null;
    }
```
* JPA를 사용하여 DB에 CUD를 구현하고 Mybatis로 조회를 구현할 경우 DB에 값을 조회하는 Mybatis 특성상 테스트 코드를 구현할 때 어려움이 있습니다. 왜냐하면 Transactional을 사용할 경우 영속성 컨텍스트에서 DB에 저장되지 않고 rollback이 되기 때문에 DB의 값을 조회하는 mybatis는 조회를 할 수 없습니다.
* 1. 샘플 데이터가 있다는 가정 하에 query문을 만들고 테스트 진행 -> git action에서는 샘플 데이터가 존재하지 않기 때문에 통과하지 못한다. ( 해결방법이 존재하나 정확히 모르겠음)
* 2. Tracnsactional을 사용하지 않고 직접 DB에 넣고 삭제 해준다.
* 2번 방식을 사용해서 테스트 진행했습니다.
```
---

# 관련 스크린샷

---
<img width="650" alt="image" src="https://github.com/The-Dark-Nights/back-end/assets/136034038/fe502db9-4a63-4692-9e6d-6f76a62c0a44">

<img width="516" alt="image" src="https://github.com/The-Dark-Nights/back-end/assets/136034038/21cd3840-1070-46a7-950f-4832c061622d">

* 테스트 진행 시 insert query문과 delete query이 작동하는 것을 확인할 수 있고 실제로 DB에 테스트를 위한 값들이 남아있지 않는 것을 확인했습니다.
---

# 테스트 계획 또는 완료 사항

---
<img width="932" alt="image" src="https://github.com/The-Dark-Nights/back-end/assets/136034038/e189de01-bf24-4963-9740-13e39718cf02">
